### PR TITLE
Add dataset category guide mapping

### DIFF
--- a/_data/dataset_category_guides.yaml
+++ b/_data/dataset_category_guides.yaml
@@ -1,0 +1,10 @@
+# This file associates dataset categories to guides.
+#
+# Each key is a dataset page key: the value is the guide page it should link to.
+# (Pages not listed here won't be linked to a guide.)
+
+adjusted-estimates-of-national-expenditure: adjusted-estimates-of-national-expenditure
+estimates-of-provincial-expenditure: estimates-of-provincial-expenditure
+frameworks-for-conditional-grants-to-provinces: frameworks-for-conditional-grants-to-provinces
+estimates-of-national-expenditure: estimates-of-national-expenditure
+performance-and-expenditure-reviews: performance-and-expenditure-reviews

--- a/_layouts/government_dataset_category.html
+++ b/_layouts/government_dataset_category.html
@@ -21,16 +21,15 @@ layout: page-shell
       {{ page_data.description | markdownify }}
       </div>
 
-      {% assign guide_path = "guides/" |append: page.data_key %}
-      {% assign guide_file_path = guide_path |append: ".md" %}
+      {% assign guide_slug = site.data.dataset_category_guides[page_data.slug] %}
+      {% if guide_slug %}
+        {% assign guide_path = "guides/" |append: guide_slug %}
 
-      {% for static_file in site.pages %}
-        {% if static_file.path == guide_file_path %}
-          <a href="/{{ guide_path }}" class="Button is-inline u-marginTop25 u-marginBottom10">
-            Learn more about {{ page_data.name }}
-          </a>
-        {% endif %}
-      {% endfor %}
+        <a href="/{{ guide_path }}" class="Button is-inline u-marginTop25 u-marginBottom10">
+          Learn more about {{ page_data.name }}
+        </a>
+      {% endif %}
+
     </div>
 
     <div class="Grid has-twoColumn">


### PR DESCRIPTION
This replaces the implicit association between dataset category and guide pages with an explicit mapping (This just captures the current implicit associations, without changing any.) 

Context: https://www.pivotaltracker.com/story/show/163184137