### PR TITLE
Add 2019 to ETS

### DIFF
--- a/_data/2016-17/national/departments/agriculture-forestry-and-fisheries.yaml
+++ b/_data/2016-17/national/departments/agriculture-forestry-and-fisheries.yaml
@@ -83,7 +83,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6383007000.0
+    - amount: 6383007000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6408750000
@@ -187,7 +187,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 238162000.0
+    - amount: 238162000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 233907000
@@ -237,7 +237,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade Promotion and Market Access
   - items:
-    - amount: 443267000.0
+    - amount: 443267000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 465267000
@@ -287,7 +287,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Fisheries
   - items:
-    - amount: 729947000.0
+    - amount: 729947000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 739418000
@@ -337,7 +337,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 906564000.0
+    - amount: 906564000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 906216000
@@ -387,7 +387,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Forestry and Natural Resources Management
   - items:
-    - amount: 1930297000.0
+    - amount: 1930297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1919401000
@@ -437,7 +437,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Food Security and Agrarian Reform
   - items:
-    - amount: 2134770000.0
+    - amount: 2134770000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2144541000

--- a/_data/2016-17/national/departments/arts-and-culture.yaml
+++ b/_data/2016-17/national/departments/arts-and-culture.yaml
@@ -78,7 +78,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 3919859000.0
+    - amount: 3919859000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3826047000
@@ -182,7 +182,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 244012000.0
+    - amount: 244012000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 242412000
@@ -232,7 +232,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 424058000.0
+    - amount: 424058000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 397558000
@@ -282,7 +282,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Institutional Governance
   - items:
-    - amount: 1076224000.0
+    - amount: 1076224000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1076224000
@@ -332,7 +332,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Arts and Culture Promotion and Development
   - items:
-    - amount: 2175565000.0
+    - amount: 2175565000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2109853000

--- a/_data/2016-17/national/departments/basic-education.yaml
+++ b/_data/2016-17/national/departments/basic-education.yaml
@@ -71,7 +71,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 21511140000.0
+    - amount: 21511140000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 21286426000
@@ -175,7 +175,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 357697000.0
+    - amount: 357697000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 360297000
@@ -225,7 +225,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1171484000.0
+    - amount: 1171484000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1163353000
@@ -275,7 +275,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Teachers, Education Human Resources and Institutional Development
   - items:
-    - amount: 1877765000.0
+    - amount: 1877765000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1844922000
@@ -325,7 +325,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Curriculum Policy, Support and Monitoring
   - items:
-    - amount: 5974456000.0
+    - amount: 5974456000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5943822000
@@ -375,7 +375,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Educational Enrichment Services
   - items:
-    - amount: 12129738000.0
+    - amount: 12129738000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11974032000

--- a/_data/2016-17/national/departments/communications.yaml
+++ b/_data/2016-17/national/departments/communications.yaml
@@ -60,7 +60,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1280888000.0
+    - amount: 1280888000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1290888000
@@ -164,7 +164,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 7897000.0
+    - amount: 7897000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7897000
@@ -214,7 +214,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Communications Policy, Research and Development
   - items:
-    - amount: 10197000.0
+    - amount: 10197000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20197000
@@ -264,7 +264,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Industry and Capacity Development
   - items:
-    - amount: 42414000.0
+    - amount: 42414000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 42414000
@@ -314,7 +314,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1220380000.0
+    - amount: 1220380000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1220380000

--- a/_data/2016-17/national/departments/cooperative-governance-and-traditional-affairs.yaml
+++ b/_data/2016-17/national/departments/cooperative-governance-and-traditional-affairs.yaml
@@ -53,7 +53,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 69314159000.0
+    - amount: 69314159000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 70815477000
@@ -158,7 +158,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 22081000.0
+    - amount: 22081000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20281000
@@ -208,7 +208,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Research and Knowledge Management
   - items:
-    - amount: 119447000.0
+    - amount: 119447000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 125928000
@@ -258,7 +258,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Traditional Affairs
   - items:
-    - amount: 247969000.0
+    - amount: 247969000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 240088000
@@ -308,7 +308,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 328092000.0
+    - amount: 328092000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 328092000
@@ -458,7 +458,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Local Government Support and Intervention Management
   - items:
-    - amount: 606805000.0
+    - amount: 606805000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 606805000
@@ -558,7 +558,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Community Work Programme
   - items:
-    - amount: 17668420000.0
+    - amount: 17668420000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 17668420000
@@ -608,7 +608,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Infrastructure and Economic Development
   - items:
-    - amount: 50321345000.0
+    - amount: 50321345000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 51825863000

--- a/_data/2016-17/national/departments/correctional-services.yaml
+++ b/_data/2016-17/national/departments/correctional-services.yaml
@@ -41,7 +41,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 20617584000.0
+    - amount: 20617584000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20588554000
@@ -145,7 +145,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 891196000.0
+    - amount: 891196000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 890966000
@@ -195,7 +195,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Reintegration
   - items:
-    - amount: 1151993000.0
+    - amount: 1151993000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1155293000
@@ -245,7 +245,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rehabilitation
   - items:
-    - amount: 1796262000.0
+    - amount: 1796262000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1796262000
@@ -295,7 +295,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Care
   - items:
-    - amount: 3697275000.0
+    - amount: 3697275000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3694515000
@@ -345,7 +345,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 13080858000.0
+    - amount: 13080858000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 13051518000

--- a/_data/2016-17/national/departments/defence-and-military-veterans.yaml
+++ b/_data/2016-17/national/departments/defence-and-military-veterans.yaml
@@ -54,7 +54,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 44579390000.0
+    - amount: 44579390000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 45088161000
@@ -158,7 +158,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 827451000.0
+    - amount: 827451000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 831459000
@@ -208,7 +208,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Defence Intelligence
   - items:
-    - amount: 3603153000.0
+    - amount: 3603153000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3813309000
@@ -258,7 +258,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Force Employment
   - items:
-    - amount: 3717249000.0
+    - amount: 3717249000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3769147000
@@ -308,7 +308,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Maritime Defence
   - items:
-    - amount: 3932914000.0
+    - amount: 3932914000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4069261000
@@ -358,7 +358,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Military Health Support
   - items:
-    - amount: 4827173000.0
+    - amount: 4827173000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4862401000
@@ -408,7 +408,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 5816992000.0
+    - amount: 5816992000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5372614000
@@ -458,7 +458,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: General Support
   - items:
-    - amount: 7049155000.0
+    - amount: 7049155000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7167594000
@@ -508,7 +508,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Air Defence
   - items:
-    - amount: 14805303000.0
+    - amount: 14805303000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15202376000

--- a/_data/2016-17/national/departments/economic-development.yaml
+++ b/_data/2016-17/national/departments/economic-development.yaml
@@ -43,7 +43,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 885778000.0
+    - amount: 885778000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 885778000
@@ -147,7 +147,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 27889000.0
+    - amount: 27889000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 27889000
@@ -197,7 +197,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Growth Path and Social Dialogue
   - items:
-    - amount: 83223000.0
+    - amount: 83223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 83223000
@@ -247,7 +247,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 774666000.0
+    - amount: 774666000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 774666000

--- a/_data/2016-17/national/departments/energy.yaml
+++ b/_data/2016-17/national/departments/energy.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 7482094000.0
+    - amount: 7482094000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7267619000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 45096000.0
+    - amount: 45096000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 44096000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Energy Policy and Planning
   - items:
-    - amount: 74378000.0
+    - amount: 74378000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73378000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Petroleum and Petroleum Products Regulation
   - items:
-    - amount: 242598000.0
+    - amount: 242598000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 246598000
@@ -312,7 +312,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 654398000.0
+    - amount: 654398000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 653898000
@@ -362,7 +362,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Nuclear Energy
   - items:
-    - amount: 687327000.0
+    - amount: 687327000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 435827000
@@ -412,7 +412,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Clean Energy
   - items:
-    - amount: 5778297000.0
+    - amount: 5778297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5813822000

--- a/_data/2016-17/national/departments/environmental-affairs.yaml
+++ b/_data/2016-17/national/departments/environmental-affairs.yaml
@@ -45,7 +45,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 5947989000.0
+    - amount: 5947989000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5943297000
@@ -149,7 +149,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 79281000.0
+    - amount: 79281000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 79281000
@@ -199,7 +199,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Chemicals and Waste Management
   - items:
-    - amount: 127517000.0
+    - amount: 127517000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 133921000
@@ -249,7 +249,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal, Authorisations and Compliance
   - items:
-    - amount: 240149000.0
+    - amount: 240149000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 240149000
@@ -299,7 +299,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Climate Change and Air Quality
   - items:
-    - amount: 484529000.0
+    - amount: 484529000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 399529000
@@ -349,7 +349,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Oceans and Coasts
   - items:
-    - amount: 655600000.0
+    - amount: 655600000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 730600000
@@ -399,7 +399,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Biodiversity and Conservation
   - items:
-    - amount: 714049000.0
+    - amount: 714049000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 870184000
@@ -449,7 +449,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 3646864000.0
+    - amount: 3646864000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3489633000

--- a/_data/2016-17/national/departments/health.yaml
+++ b/_data/2016-17/national/departments/health.yaml
@@ -82,7 +82,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 36468018000.0
+    - amount: 36468018000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 36253925000
@@ -186,7 +186,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 225005000.0
+    - amount: 225005000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 224917000
@@ -236,7 +236,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Primary Health Care Services
   - items:
-    - amount: 457078000.0
+    - amount: 457078000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 456578000
@@ -286,7 +286,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 587807000.0
+    - amount: 587807000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 596646000
@@ -336,7 +336,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Health Insurance, Health Planning and Systems Enablement
   - items:
-    - amount: 1596919000.0
+    - amount: 1596919000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1603875000
@@ -386,7 +386,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Health Regulation and Compliance Management
   - items:
-    - amount: 14442144000.0
+    - amount: 14442144000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 14378878000
@@ -436,7 +436,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: HIV and AIDS, Tuberculosis, and Maternal and Child Health
   - items:
-    - amount: 19159065000.0
+    - amount: 19159065000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 18993031000

--- a/_data/2016-17/national/departments/higher-education-and-training.yaml
+++ b/_data/2016-17/national/departments/higher-education-and-training.yaml
@@ -64,7 +64,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 41843955000.0
+    - amount: 41843955000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 41880138000
@@ -169,7 +169,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 54843000.0
+    - amount: 54843000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 58253000
@@ -269,7 +269,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Planning, Policy and Strategy
   - items:
-    - amount: 110699000.0
+    - amount: 110699000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 112631000
@@ -319,7 +319,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Skills Development
   - items:
-    - amount: 318318000.0
+    - amount: 318318000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 359519000
@@ -469,7 +469,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Technical and Vocational Education and Training
   - items:
-    - amount: 8515770000.0
+    - amount: 8515770000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 8502290000
@@ -519,7 +519,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Vocational and Continuing Education and Training
   - items:
-    - amount: 14690000000.0
+    - amount: 14690000000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15800000000
@@ -569,7 +569,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 32844325000.0
+    - amount: 32844325000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 32847445000

--- a/_data/2016-17/national/departments/home-affairs.yaml
+++ b/_data/2016-17/national/departments/home-affairs.yaml
@@ -55,7 +55,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6450822000.0
+    - amount: 6450822000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7348725000
@@ -159,7 +159,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 720919000.0
+    - amount: 720919000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 637571000
@@ -209,7 +209,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Immigration Affairs
   - items:
-    - amount: 1598202000.0
+    - amount: 1598202000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1769594000
@@ -259,7 +259,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 4131701000.0
+    - amount: 4131701000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4941560000

--- a/_data/2016-17/national/departments/human-settlements.yaml
+++ b/_data/2016-17/national/departments/human-settlements.yaml
@@ -72,7 +72,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 30943381000.0
+    - amount: 30943381000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 30543381000
@@ -176,7 +176,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 74338000.0
+    - amount: 74338000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73538000
@@ -226,7 +226,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Human Settlements Policy, Strategy and Planning
   - items:
-    - amount: 169800000.0
+    - amount: 169800000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 165600000
@@ -276,7 +276,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Human Settlements Delivery Support
   - items:
-    - amount: 435116000.0
+    - amount: 435116000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 440616000
@@ -326,7 +326,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 30264127000.0
+    - amount: 30264127000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 29863627000

--- a/_data/2016-17/national/departments/independent-police-investigative-directorate.yaml
+++ b/_data/2016-17/national/departments/independent-police-investigative-directorate.yaml
@@ -60,7 +60,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 234781000.0
+    - amount: 234781000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 234781000
@@ -164,7 +164,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 4618000.0
+    - amount: 4618000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4468000
@@ -214,7 +214,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Compliance Monitoring and Stakeholder Management
   - items:
-    - amount: 5096000.0
+    - amount: 5096000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5476000
@@ -264,7 +264,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal Services
   - items:
-    - amount: 74245000.0
+    - amount: 74245000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 74015000
@@ -314,7 +314,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 150822000.0
+    - amount: 150822000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 150822000

--- a/_data/2016-17/national/departments/international-relations-and-cooperation.yaml
+++ b/_data/2016-17/national/departments/international-relations-and-cooperation.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 5698634000.0
+    - amount: 5698634000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6510854000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 246280000.0
+    - amount: 246280000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 363557000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Diplomacy and Protocol Services
   - items:
-    - amount: 466945000.0
+    - amount: 466945000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 525201000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Cooperation
   - items:
-    - amount: 635231000.0
+    - amount: 635231000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 734321000
@@ -312,7 +312,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Transfers
   - items:
-    - amount: 1418521000.0
+    - amount: 1418521000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1381600000
@@ -362,7 +362,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 2931657000.0
+    - amount: 2931657000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3506175000

--- a/_data/2016-17/national/departments/justice-and-constitutional-development.yaml
+++ b/_data/2016-17/national/departments/justice-and-constitutional-development.yaml
@@ -72,7 +72,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 14983969000.0
+    - amount: 14983969000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15010773000
@@ -176,7 +176,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 1032176000.0
+    - amount: 1032176000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1045669000
@@ -226,7 +226,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: State Legal Services
   - items:
-    - amount: 1857833000.0
+    - amount: 1857833000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1872884000
@@ -276,7 +276,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1880769000.0
+    - amount: 1880769000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1830769000
@@ -326,7 +326,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 3193544000.0
+    - amount: 3193544000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3118544000
@@ -376,7 +376,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Auxiliary and Associated Services
   - items:
-    - amount: 3373988000.0
+    - amount: 3373988000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3394538000
@@ -426,7 +426,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Prosecuting Authority
   - items:
-    - amount: 5526428000.0
+    - amount: 5526428000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5579138000

--- a/_data/2016-17/national/departments/labour.yaml
+++ b/_data/2016-17/national/departments/labour.yaml
@@ -66,7 +66,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 2686867000.0
+    - amount: 2686867000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2704234000
@@ -170,7 +170,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 430778000.0
+    - amount: 430778000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 471830000
@@ -220,7 +220,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Inspection and Enforcement Services
   - items:
-    - amount: 488297000.0
+    - amount: 488297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 497297000
@@ -270,7 +270,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Employment Services
   - items:
-    - amount: 845111000.0
+    - amount: 845111000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 815111000
@@ -320,7 +320,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 922681000.0
+    - amount: 922681000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 919996000

--- a/_data/2016-17/national/departments/mineral-resources.yaml
+++ b/_data/2016-17/national/departments/mineral-resources.yaml
@@ -45,7 +45,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1618542000.0
+    - amount: 1618542000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1638542000
@@ -149,7 +149,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 175840000.0
+    - amount: 175840000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 184431000
@@ -199,7 +199,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Mine Health and Safety
   - items:
-    - amount: 260443000.0
+    - amount: 260443000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 263715000
@@ -249,7 +249,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Mineral Regulation
   - items:
-    - amount: 293223000.0
+    - amount: 293223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 308870000
@@ -299,7 +299,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 889036000.0
+    - amount: 889036000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 881526000

--- a/_data/2016-17/national/departments/national-treasury.yaml
+++ b/_data/2016-17/national/departments/national-treasury.yaml
@@ -82,7 +82,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 26957304000.0
+    - amount: 26957304000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 28726061000
@@ -186,7 +186,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 133892000.0
+    - amount: 133892000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 135387000
@@ -236,7 +236,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Economic Policy, Tax, Financial Regulation and Research
   - items:
-    - amount: 256965000.0
+    - amount: 256965000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 266104000
@@ -286,7 +286,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Finance and Budget Management
   - items:
-    - amount: 366665000.0
+    - amount: 366665000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 363629000
@@ -336,7 +336,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 751362000.0
+    - amount: 751362000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 807090000
@@ -386,7 +386,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Financial Accounting and Supply Chain Management Systems
   - items:
-    - amount: 1247442000.0
+    - amount: 1247442000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3254926000
@@ -436,7 +436,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Financial Relations
   - items:
-    - amount: 3116930000.0
+    - amount: 3116930000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3264890000
@@ -486,7 +486,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Asset and Liability Management
   - items:
-    - amount: 3143863000.0
+    - amount: 3143863000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2774593000
@@ -536,7 +536,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Technical Support and Development Finance
   - items:
-    - amount: 3962941000.0
+    - amount: 3962941000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3962941000
@@ -586,7 +586,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Civil and Military Pensions, Contributions to Funds and Other Benefits
   - items:
-    - amount: 4542805000.0
+    - amount: 4542805000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4562062000
@@ -636,7 +636,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Financial Intelligence and State Security
   - items:
-    - amount: 9434439000.0
+    - amount: 9434439000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9334439000
@@ -686,7 +686,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Revenue Administration
   - items:
-    - amount: 519893814000.0
+    - amount: 519893814000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 525742590000

--- a/_data/2016-17/national/departments/office-of-the-chief-justice-and-judicial-administration.yaml
+++ b/_data/2016-17/national/departments/office-of-the-chief-justice-and-judicial-administration.yaml
@@ -61,7 +61,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 742417000.0
+    - amount: 742417000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 783379000
@@ -165,7 +165,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 32643000.0
+    - amount: 32643000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 34359000
@@ -215,7 +215,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Judicial Education and Research
   - items:
-    - amount: 69411000.0
+    - amount: 69411000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 99479000
@@ -265,7 +265,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 640363000.0
+    - amount: 640363000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 649541000
@@ -315,7 +315,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Judicial Support and Court Administration
   - items:
-    - amount: 873748000.0
+    - amount: 873748000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 873748000

--- a/_data/2016-17/national/departments/parliament.yaml
+++ b/_data/2016-17/national/departments/parliament.yaml
@@ -22,7 +22,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1566922000.0
+    - amount: 1566922000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1594238000
@@ -177,7 +177,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Strategic Leadership and Governance
   - items:
-    - amount: 133204000.0
+    - amount: 133204000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 125722000
@@ -227,7 +227,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public and International Participation
   - items:
-    - amount: 234170000.0
+    - amount: 234170000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 234170000
@@ -327,7 +327,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Support Services
   - items:
-    - amount: 364518000.0
+    - amount: 364518000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 372000000
@@ -377,7 +377,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Associated Services
   - items:
-    - amount: 375458000.0
+    - amount: 375458000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 402774000
@@ -427,7 +427,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legislation and Oversight
   - items:
-    - amount: 459572000.0
+    - amount: 459572000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 459572000
@@ -477,7 +477,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 503132000.0
+    - amount: 503132000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 503132000

--- a/_data/2016-17/national/departments/planning-monitoring-and-evaluation.yaml
+++ b/_data/2016-17/national/departments/planning-monitoring-and-evaluation.yaml
@@ -68,6 +68,9 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
+    - amount: 717694000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 754200000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -113,10 +116,10 @@ budget_actual:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
+    real:
+    - amount: 838079021
       financial_year: 2015-16
       phase: Main appropriation
-    real:
     - amount: 880708488
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -162,9 +165,6 @@ budget_actual:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
   notices:
   - Please note that the data for 2013 and 2014 has not been published on vulekamali.
 budget_actual_programmes:
@@ -172,6 +172,9 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
+    - amount: 59567000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 60431000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -217,111 +220,11 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
     name: Institutional Performance Monitoring and Evaluation
   - items:
-    - amount: 82197000
-      financial_year: 2015-16
-      phase: Adjusted appropriation
-    - amount: 75632000
-      financial_year: 2015-16
-      phase: Final Appropriation
-    - amount: 70736000
-      financial_year: 2015-16
-      phase: Audit Outcome
-    - amount: 103237000.0
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: 91508000
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: 88233000
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: 84216000
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2013-14
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2013-14
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2013-14
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2013-14
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2014-15
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Audit Outcome
-    - amount: null
+    - amount: 69784000
       financial_year: 2015-16
       phase: Main appropriation
-    name: National Planning
-  - items:
-    - amount: 92324000
-      financial_year: 2015-16
-      phase: Adjusted appropriation
-    - amount: 90087000
-      financial_year: 2015-16
-      phase: Final Appropriation
-    - amount: 89560000
-      financial_year: 2015-16
-      phase: Audit Outcome
-    - amount: 108854000.0
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: 91751000
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: 93162000
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: 89749000
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2013-14
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2013-14
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2013-14
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2013-14
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2014-15
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
-    name: Outcomes Monitoring and Evaluation
-  - items:
     - amount: 104185000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -367,11 +270,111 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
     name: Administration
   - items:
+    - amount: 85604000
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: 92324000
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: 90087000
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: 89560000
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: 108854000.0
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: 91751000
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: 93162000
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: 89749000
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2013-14
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2014-15
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Audit Outcome
+    name: Outcomes Monitoring and Evaluation
+  - items:
+    - amount: 88197000
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: 82197000
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: 75632000
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: 70736000
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: 103237000.0
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: 91508000
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: 88233000
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: 84216000
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2013-14
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2014-15
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Audit Outcome
+    name: National Planning
+  - items:
+    - amount: 414542000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 415063000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -417,9 +420,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
     name: National Youth Development
 contributed_datasets:
 - contributor: International Budget Partnership

--- a/_data/2016-17/national/departments/police.yaml
+++ b/_data/2016-17/national/departments/police.yaml
@@ -57,7 +57,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 76377059000.0
+    - amount: 76377059000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 76720848000
@@ -161,7 +161,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 2331523000.0
+    - amount: 2331523000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2427731000
@@ -211,7 +211,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Protection and Security Services
   - items:
-    - amount: 3110379000.0
+    - amount: 3110379000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3146936000
@@ -261,7 +261,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Crime Intelligence
   - items:
-    - amount: 15815983000.0
+    - amount: 15815983000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16092427000
@@ -311,7 +311,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Detective Services
   - items:
-    - amount: 16264210000.0
+    - amount: 16264210000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16609332000
@@ -361,7 +361,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 38854964000.0
+    - amount: 38854964000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 38444422000

--- a/_data/2016-17/national/departments/public-enterprises.yaml
+++ b/_data/2016-17/national/departments/public-enterprises.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 267481000.0
+    - amount: 267481000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23302594000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 23829000.0
+    - amount: 23829000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23509000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal and Governance
   - items:
-    - amount: 85065000.0
+    - amount: 85065000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23117211000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Portfolio Management and Strategic Partnerships
   - items:
-    - amount: 158587000.0
+    - amount: 158587000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 161874000

--- a/_data/2016-17/national/departments/public-service-and-administration.yaml
+++ b/_data/2016-17/national/departments/public-service-and-administration.yaml
@@ -73,7 +73,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 930868000.0
+    - amount: 930868000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 941482000
@@ -177,7 +177,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 21493000.0
+    - amount: 21493000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 21493000
@@ -227,7 +227,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Government Chief Information Officer
   - items:
-    - amount: 37465000.0
+    - amount: 37465000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 38606000
@@ -277,7 +277,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy Development, Research and Analysis
   - items:
-    - amount: 68607000.0
+    - amount: 68607000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73607000
@@ -327,7 +327,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Labour Relations and Human Resource Management
   - items:
-    - amount: 219702000.0
+    - amount: 219702000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 221441000
@@ -377,7 +377,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 269027000.0
+    - amount: 269027000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 272871000
@@ -427,7 +427,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Governance of Public Administration
   - items:
-    - amount: 314574000.0
+    - amount: 314574000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 313464000

--- a/_data/2016-17/national/departments/public-works.yaml
+++ b/_data/2016-17/national/departments/public-works.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6411087000.0
+    - amount: 6411087000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6312222000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 47223000.0
+    - amount: 47223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 45723000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Intergovernmental Coordination
   - items:
-    - amount: 92672000.0
+    - amount: 92672000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 92822000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Prestige Policy
   - items:
-    - amount: 475996000.0
+    - amount: 475996000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 477346000
@@ -312,7 +312,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1992234000.0
+    - amount: 1992234000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1953369000
@@ -362,7 +362,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Expanded Public Works Programme
   - items:
-    - amount: 3802962000.0
+    - amount: 3802962000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3742962000

--- a/_data/2016-17/national/departments/rural-development-and-land-reform.yaml
+++ b/_data/2016-17/national/departments/rural-development-and-land-reform.yaml
@@ -61,7 +61,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 9379684000.0
+    - amount: 9379684000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9197361000
@@ -165,7 +165,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 799903000.0
+    - amount: 799903000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 748063000
@@ -215,7 +215,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Geomatics Management Services
   - items:
-    - amount: 1264265000.0
+    - amount: 1264265000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1324944000
@@ -265,7 +265,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1975739000.0
+    - amount: 1975739000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1984577000
@@ -315,7 +315,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rural Development
   - items:
-    - amount: 2602669000.0
+    - amount: 2602669000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2602669000
@@ -365,7 +365,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Restitution
   - items:
-    - amount: 2737108000.0
+    - amount: 2737108000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2537108000

--- a/_data/2016-17/national/departments/science-and-technology.yaml
+++ b/_data/2016-17/national/departments/science-and-technology.yaml
@@ -60,7 +60,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 7482120000.0
+    - amount: 7482119996
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7466106000
@@ -109,7 +109,7 @@ budget_actual:
       financial_year: 2014-15
       phase: Audit Outcome
     real:
-    - amount: 8737160692
+    - amount: 8737160687
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 8718460525
@@ -164,7 +164,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 121997000.0
+    - amount: 121997000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 121359000
@@ -214,7 +214,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Cooperation and Resources
   - items:
-    - amount: 299776000.0
+    - amount: 299776000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 300537000
@@ -264,7 +264,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1008817000.0
+    - amount: 1008817000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1008514000
@@ -314,7 +314,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Technology Innovation
   - items:
-    - amount: 1804464000.0
+    - amount: 1804464000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1796871000
@@ -364,7 +364,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Socio-Economic Innovation Partnerships
   - items:
-    - amount: 4247066000.0
+    - amount: 4247065996
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4238825000

--- a/_data/2016-17/national/departments/small-business-development.yaml
+++ b/_data/2016-17/national/departments/small-business-development.yaml
@@ -38,7 +38,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1103188000.0
+    - amount: 1103188000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1127520000
@@ -143,9 +143,6 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 15188000.0
-      financial_year: 2015-16
-      phase: Main appropriation
     - amount: 11711000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -180,6 +177,9 @@ budget_actual_programmes:
       financial_year: 2014-15
       phase: Audit Outcome
     - amount: null
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: null
       financial_year: 2016-17
       phase: Main appropriation
     - amount: null
@@ -192,6 +192,56 @@ budget_actual_programmes:
       financial_year: 2016-17
       phase: Audit Outcome
     name: Cooperatives Support and Development
+  - items:
+    - amount: 15188000
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2013-14
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2014-15
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    name: Co-operatives Support and Development
   - items:
     - amount: 25835000
       financial_year: 2016-17
@@ -293,7 +343,7 @@ budget_actual_programmes:
       phase: Adjusted appropriation
     name: Small Medium and Micro Enterprises and Cooperatives Policy and Research
   - items:
-    - amount: 64025000.0
+    - amount: 64025000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 81387000
@@ -343,7 +393,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1023975000.0
+    - amount: 1023975000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1034422000

--- a/_data/2016-17/national/departments/social-development.yaml
+++ b/_data/2016-17/national/departments/social-development.yaml
@@ -51,7 +51,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 138168640000.0
+    - amount: 138168640000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 137893640000
@@ -155,7 +155,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 297015000.0
+    - amount: 297015000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 297015000
@@ -205,7 +205,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 359820000.0
+    - amount: 359820000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 359820000
@@ -255,7 +255,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Policy and Integrated Service Delivery
   - items:
-    - amount: 662362000.0
+    - amount: 662362000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 677362000
@@ -305,7 +305,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Welfare Services Policy Development and Implementation Support
   - items:
-    - amount: 6756165000.0
+    - amount: 6756165000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6741165000
@@ -355,7 +355,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Security Policy and Administration
   - items:
-    - amount: 130093278000.0
+    - amount: 130093278000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 129818278000

--- a/_data/2016-17/national/departments/sport-and-recreation-south-africa.yaml
+++ b/_data/2016-17/national/departments/sport-and-recreation-south-africa.yaml
@@ -42,7 +42,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 988548000.0
+    - amount: 988548000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 980879000
@@ -146,7 +146,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 9678000.0
+    - amount: 9678000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6788000
@@ -196,7 +196,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Sport Infrastructure Support
   - items:
-    - amount: 92152000.0
+    - amount: 92152000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 75552000
@@ -246,7 +246,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Winning Nation
   - items:
-    - amount: 124828000.0
+    - amount: 124828000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 115477000
@@ -296,7 +296,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 133244000.0
+    - amount: 133244000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 154017000
@@ -346,7 +346,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Sport Support
   - items:
-    - amount: 628646000.0
+    - amount: 628646000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 629045000

--- a/_data/2016-17/national/departments/statistics-south-africa.yaml
+++ b/_data/2016-17/national/departments/statistics-south-africa.yaml
@@ -64,7 +64,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 2245208000.0
+    - amount: 2245208000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2323256000
@@ -168,7 +168,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 66286000.0
+    - amount: 66286000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 64587000
@@ -218,7 +218,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Methodology, Standards and Research
   - items:
-    - amount: 133675000.0
+    - amount: 133675000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 144882000
@@ -268,7 +268,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Population and Social Statistics
   - items:
-    - amount: 214445000.0
+    - amount: 214445000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 215868000
@@ -318,7 +318,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Economic Statistics
   - items:
-    - amount: 235976000.0
+    - amount: 235976000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 241152000
@@ -368,7 +368,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Survey Operations
   - items:
-    - amount: 250004000.0
+    - amount: 250004000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 246106000
@@ -418,7 +418,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Statistical Support and Informatics
   - items:
-    - amount: 553560000.0
+    - amount: 553560000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 556828000
@@ -468,7 +468,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Statistical Collection and Outreach
   - items:
-    - amount: 791262000.0
+    - amount: 791262000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 853833000

--- a/_data/2016-17/national/departments/telecommunications-and-postal-services.yaml
+++ b/_data/2016-17/national/departments/telecommunications-and-postal-services.yaml
@@ -47,7 +47,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1413328000.0
+    - amount: 1413328000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1405253000
@@ -152,7 +152,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 43447000.0
+    - amount: 43447000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 43447000
@@ -202,7 +202,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Affairs and Trade
   - items:
-    - amount: 105578000.0
+    - amount: 105578000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 105578000
@@ -252,7 +252,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Research and Capacity Development
   - items:
-    - amount: 173650000.0
+    - amount: 173650000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 180349000
@@ -302,7 +302,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 447889000.0
+    - amount: 447889000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 447889000
@@ -352,7 +352,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: ICT Enterprise Development and SOE Oversight
   - items:
-    - amount: 642764000.0
+    - amount: 642764000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 627990000

--- a/_data/2016-17/national/departments/the-presidency.yaml
+++ b/_data/2016-17/national/departments/the-presidency.yaml
@@ -53,7 +53,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 510330000.0
+    - amount: 510330000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 475929000
@@ -157,7 +157,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 5726000.0
+    - amount: 5726000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5726000
@@ -207,7 +207,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 26390000.0
+    - amount: 26390000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 32268000
@@ -257,7 +257,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Executive Support
   - items:
-    - amount: 483940000.0
+    - amount: 483940000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 443661000

--- a/_data/2016-17/national/departments/tourism.yaml
+++ b/_data/2016-17/national/departments/tourism.yaml
@@ -52,7 +52,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1800233000.0
+    - amount: 1800233000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1794178000
@@ -156,7 +156,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 46726000.0
+    - amount: 46726000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 47308000
@@ -206,7 +206,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Tourism
   - items:
-    - amount: 231773000.0
+    - amount: 231773000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 233656000
@@ -256,7 +256,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 306163000.0
+    - amount: 306163000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 307000000
@@ -306,7 +306,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Domestic Tourism
   - items:
-    - amount: 1215571000.0
+    - amount: 1215571000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1206214000

--- a/_data/2016-17/national/departments/trade-and-industry.yaml
+++ b/_data/2016-17/national/departments/trade-and-industry.yaml
@@ -74,7 +74,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 9593715000.0
+    - amount: 9593715000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9497844000
@@ -229,7 +229,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Investment South Africa
   - items:
-    - amount: 164754000.0
+    - amount: 164754000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 116576000
@@ -279,7 +279,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Trade and Economic Development
   - items:
-    - amount: 263224000.0
+    - amount: 263224000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 89704000
@@ -329,7 +329,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Special Economic Zones and Economic Transformation
   - items:
-    - amount: 294496000.0
+    - amount: 294496000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 296385000
@@ -429,7 +429,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade Export South Africa
   - items:
-    - amount: 412328000.0
+    - amount: 412328000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 435016000
@@ -479,7 +479,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade and Investment South Africa
   - items:
-    - amount: 689740000.0
+    - amount: 689740000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 768304000
@@ -529,7 +529,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1973534000.0
+    - amount: 1973534000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1964268000
@@ -579,7 +579,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Industrial Development
   - items:
-    - amount: 5795639000.0
+    - amount: 5795639000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5827591000

--- a/_data/2016-17/national/departments/transport.yaml
+++ b/_data/2016-17/national/departments/transport.yaml
@@ -57,7 +57,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 53357297000.0
+    - amount: 53357297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 53615077000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Main appropriation
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 80583000.0
+    - amount: 80583000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 88083000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Integrated Transport Planning
   - items:
-    - amount: 111089000.0
+    - amount: 111089000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 121089000
@@ -312,7 +312,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Maritime Transport
   - items:
-    - amount: 149526000.0
+    - amount: 149526000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 149526000
@@ -362,7 +362,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Civil Aviation
   - items:
-    - amount: 383457000.0
+    - amount: 383457000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 383457000
@@ -412,7 +412,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 11536361000.0
+    - amount: 11536361000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11518861000
@@ -462,7 +462,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Transport
   - items:
-    - amount: 18311364000.0
+    - amount: 18311364000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 18311364000
@@ -512,7 +512,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rail Transport
   - items:
-    - amount: 22784917000.0
+    - amount: 22784917000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23042697000

--- a/_data/2016-17/national/departments/water-and-sanitation.yaml
+++ b/_data/2016-17/national/departments/water-and-sanitation.yaml
@@ -68,7 +68,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 16446530000.0
+    - amount: 16446530000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15746530000
@@ -172,7 +172,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 231339000.0
+    - amount: 231339000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 284609000
@@ -222,7 +222,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water Sector Regulation
   - items:
-    - amount: 808655000.0
+    - amount: 808655000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 743963000
@@ -272,7 +272,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water Planning and Information Management
   - items:
-    - amount: 1444582000.0
+    - amount: 1444582000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1414674000
@@ -322,7 +322,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water and Sanitation Services
   - items:
-    - amount: 1526167000.0
+    - amount: 1526167000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1487534000
@@ -372,7 +372,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 12435787000.0
+    - amount: 12435787000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11815750000

--- a/_data/2016-17/national/departments/women.yaml
+++ b/_data/2016-17/national/departments/women.yaml
@@ -26,7 +26,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 187002000.0
+    - amount: 187002000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 189102000
@@ -131,7 +131,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 6170000.0
+    - amount: 6170000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6328000
@@ -181,7 +181,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Research, Policy Coordination and Knowledge Management
   - items:
-    - amount: 13151000.0
+    - amount: 13151000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16967000
@@ -281,7 +281,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Stakeholder Coordination and Knowledge Management
   - items:
-    - amount: 80451000.0
+    - amount: 80451000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 78876000
@@ -381,7 +381,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Transformation and Economic Empowerment
   - items:
-    - amount: 87230000.0
+    - amount: 87230000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 86931000

--- a/_data/2017-18/national/departments/agriculture-forestry-and-fisheries.yaml
+++ b/_data/2017-18/national/departments/agriculture-forestry-and-fisheries.yaml
@@ -80,7 +80,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6383007000.0
+    - amount: 6383007000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6408750000
@@ -184,7 +184,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 238162000.0
+    - amount: 238162000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 233907000
@@ -234,7 +234,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade Promotion and Market Access
   - items:
-    - amount: 443267000.0
+    - amount: 443267000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 465267000
@@ -284,7 +284,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Fisheries
   - items:
-    - amount: 729947000.0
+    - amount: 729947000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 739418000
@@ -334,7 +334,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 906564000.0
+    - amount: 906564000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 906216000
@@ -384,7 +384,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Forestry and Natural Resources Management
   - items:
-    - amount: 1930297000.0
+    - amount: 1930297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1919401000
@@ -434,7 +434,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Food Security and Agrarian Reform
   - items:
-    - amount: 2134770000.0
+    - amount: 2134770000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2144541000

--- a/_data/2017-18/national/departments/arts-and-culture.yaml
+++ b/_data/2017-18/national/departments/arts-and-culture.yaml
@@ -75,7 +75,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 3919859000.0
+    - amount: 3919859000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3826047000
@@ -179,7 +179,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 244012000.0
+    - amount: 244012000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 242412000
@@ -229,7 +229,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 424058000.0
+    - amount: 424058000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 397558000
@@ -279,7 +279,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Institutional Governance
   - items:
-    - amount: 1076224000.0
+    - amount: 1076224000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1076224000
@@ -329,7 +329,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Arts and Culture Promotion and Development
   - items:
-    - amount: 2175565000.0
+    - amount: 2175565000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2109853000

--- a/_data/2017-18/national/departments/basic-education.yaml
+++ b/_data/2017-18/national/departments/basic-education.yaml
@@ -59,7 +59,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 21511140000.0
+    - amount: 21511140000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 21286426000
@@ -163,7 +163,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 357697000.0
+    - amount: 357697000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 360297000
@@ -213,7 +213,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1171484000.0
+    - amount: 1171484000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1163353000
@@ -263,7 +263,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Teachers, Education Human Resources and Institutional Development
   - items:
-    - amount: 1877765000.0
+    - amount: 1877765000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1844922000
@@ -313,7 +313,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Curriculum Policy, Support and Monitoring
   - items:
-    - amount: 5974456000.0
+    - amount: 5974456000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5943822000
@@ -363,7 +363,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Educational Enrichment Services
   - items:
-    - amount: 12129738000.0
+    - amount: 12129738000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11974032000

--- a/_data/2017-18/national/departments/communications.yaml
+++ b/_data/2017-18/national/departments/communications.yaml
@@ -63,7 +63,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1280888000.0
+    - amount: 1280888000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1290888000
@@ -167,7 +167,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 7897000.0
+    - amount: 7897000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7897000
@@ -217,7 +217,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Communications Policy, Research and Development
   - items:
-    - amount: 10197000.0
+    - amount: 10197000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20197000
@@ -267,7 +267,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Industry and Capacity Development
   - items:
-    - amount: 42414000.0
+    - amount: 42414000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 42414000
@@ -317,7 +317,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1220380000.0
+    - amount: 1220380000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1220380000

--- a/_data/2017-18/national/departments/cooperative-governance-and-traditional-affairs.yaml
+++ b/_data/2017-18/national/departments/cooperative-governance-and-traditional-affairs.yaml
@@ -79,7 +79,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 69314159000.0
+    - amount: 69314159000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 70815477000
@@ -184,7 +184,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 22081000.0
+    - amount: 22081000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20281000
@@ -234,7 +234,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Research and Knowledge Management
   - items:
-    - amount: 119447000.0
+    - amount: 119447000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 125928000
@@ -284,7 +284,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Traditional Affairs
   - items:
-    - amount: 247969000.0
+    - amount: 247969000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 240088000
@@ -334,7 +334,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 328092000.0
+    - amount: 328092000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 328092000
@@ -484,7 +484,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Local Government Support and Intervention Management
   - items:
-    - amount: 606805000.0
+    - amount: 606805000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 606805000
@@ -584,7 +584,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Community Work Programme
   - items:
-    - amount: 17668420000.0
+    - amount: 17668420000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 17668420000
@@ -634,7 +634,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Infrastructure and Economic Development
   - items:
-    - amount: 50321345000.0
+    - amount: 50321345000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 51825863000

--- a/_data/2017-18/national/departments/correctional-services.yaml
+++ b/_data/2017-18/national/departments/correctional-services.yaml
@@ -45,7 +45,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 20617584000.0
+    - amount: 20617584000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20588554000
@@ -149,7 +149,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 891196000.0
+    - amount: 891196000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 890966000
@@ -199,7 +199,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Reintegration
   - items:
-    - amount: 1151993000.0
+    - amount: 1151993000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1155293000
@@ -249,7 +249,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rehabilitation
   - items:
-    - amount: 1796262000.0
+    - amount: 1796262000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1796262000
@@ -299,7 +299,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Care
   - items:
-    - amount: 3697275000.0
+    - amount: 3697275000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3694515000
@@ -349,7 +349,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 13080858000.0
+    - amount: 13080858000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 13051518000

--- a/_data/2017-18/national/departments/defence-and-military-veterans.yaml
+++ b/_data/2017-18/national/departments/defence-and-military-veterans.yaml
@@ -61,7 +61,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 44579390000.0
+    - amount: 44579390000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 45088161000
@@ -165,7 +165,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 827451000.0
+    - amount: 827451000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 831459000
@@ -215,7 +215,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Defence Intelligence
   - items:
-    - amount: 3603153000.0
+    - amount: 3603153000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3813309000
@@ -265,7 +265,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Force Employment
   - items:
-    - amount: 3717249000.0
+    - amount: 3717249000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3769147000
@@ -315,7 +315,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Maritime Defence
   - items:
-    - amount: 3932914000.0
+    - amount: 3932914000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4069261000
@@ -365,7 +365,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Military Health Support
   - items:
-    - amount: 4827173000.0
+    - amount: 4827173000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4862401000
@@ -415,7 +415,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 5816992000.0
+    - amount: 5816992000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5372614000
@@ -465,7 +465,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: General Support
   - items:
-    - amount: 7049155000.0
+    - amount: 7049155000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7167594000
@@ -515,7 +515,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Air Defence
   - items:
-    - amount: 14805303000.0
+    - amount: 14805303000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15202376000

--- a/_data/2017-18/national/departments/economic-development.yaml
+++ b/_data/2017-18/national/departments/economic-development.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 885778000.0
+    - amount: 885778000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 885778000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 27889000.0
+    - amount: 27889000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 27889000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Growth Path and Social Dialogue
   - items:
-    - amount: 83223000.0
+    - amount: 83223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 83223000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 774666000.0
+    - amount: 774666000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 774666000

--- a/_data/2017-18/national/departments/energy.yaml
+++ b/_data/2017-18/national/departments/energy.yaml
@@ -51,7 +51,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 7482094000.0
+    - amount: 7482094000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7267619000
@@ -155,7 +155,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 45096000.0
+    - amount: 45096000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 44096000
@@ -205,7 +205,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Energy Policy and Planning
   - items:
-    - amount: 74378000.0
+    - amount: 74378000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73378000
@@ -255,7 +255,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Petroleum and Petroleum Products Regulation
   - items:
-    - amount: 242598000.0
+    - amount: 242598000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 246598000
@@ -305,7 +305,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 654398000.0
+    - amount: 654398000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 653898000
@@ -355,7 +355,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Nuclear Energy
   - items:
-    - amount: 687327000.0
+    - amount: 687327000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 435827000
@@ -405,7 +405,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Clean Energy
   - items:
-    - amount: 5778297000.0
+    - amount: 5778297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5813822000

--- a/_data/2017-18/national/departments/environmental-affairs.yaml
+++ b/_data/2017-18/national/departments/environmental-affairs.yaml
@@ -35,7 +35,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 5947989000.0
+    - amount: 5947989000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5943297000
@@ -139,7 +139,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 79281000.0
+    - amount: 79281000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 79281000
@@ -189,7 +189,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Chemicals and Waste Management
   - items:
-    - amount: 127517000.0
+    - amount: 127517000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 133921000
@@ -239,7 +239,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal, Authorisations and Compliance
   - items:
-    - amount: 240149000.0
+    - amount: 240149000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 240149000
@@ -289,7 +289,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Climate Change and Air Quality
   - items:
-    - amount: 484529000.0
+    - amount: 484529000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 399529000
@@ -339,7 +339,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Oceans and Coasts
   - items:
-    - amount: 655600000.0
+    - amount: 655600000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 730600000
@@ -389,7 +389,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Biodiversity and Conservation
   - items:
-    - amount: 714049000.0
+    - amount: 714049000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 870184000
@@ -439,7 +439,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 3646864000.0
+    - amount: 3646864000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3489633000

--- a/_data/2017-18/national/departments/health.yaml
+++ b/_data/2017-18/national/departments/health.yaml
@@ -76,7 +76,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 36468018000.0
+    - amount: 36468018000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 36253925000
@@ -180,7 +180,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 225005000.0
+    - amount: 225005000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 224917000
@@ -230,7 +230,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Primary Health Care Services
   - items:
-    - amount: 457078000.0
+    - amount: 457078000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 456578000
@@ -280,7 +280,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 587807000.0
+    - amount: 587807000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 596646000
@@ -330,7 +330,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Health Insurance, Health Planning and Systems Enablement
   - items:
-    - amount: 1596919000.0
+    - amount: 1596919000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1603875000
@@ -380,7 +380,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Health Regulation and Compliance Management
   - items:
-    - amount: 14442144000.0
+    - amount: 14442144000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 14378878000
@@ -430,7 +430,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: HIV and AIDS, Tuberculosis, and Maternal and Child Health
   - items:
-    - amount: 19159065000.0
+    - amount: 19159065000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 18993031000

--- a/_data/2017-18/national/departments/higher-education-and-training.yaml
+++ b/_data/2017-18/national/departments/higher-education-and-training.yaml
@@ -70,7 +70,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 41843955000.0
+    - amount: 41843955000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 41880138000
@@ -175,7 +175,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 54843000.0
+    - amount: 54843000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 58253000
@@ -275,7 +275,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Planning, Policy and Strategy
   - items:
-    - amount: 110699000.0
+    - amount: 110699000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 112631000
@@ -325,7 +325,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Skills Development
   - items:
-    - amount: 318318000.0
+    - amount: 318318000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 359519000
@@ -475,7 +475,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Technical and Vocational Education and Training
   - items:
-    - amount: 8515770000.0
+    - amount: 8515770000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 8502290000
@@ -525,7 +525,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Vocational and Continuing Education and Training
   - items:
-    - amount: 14690000000.0
+    - amount: 14690000000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15800000000
@@ -575,7 +575,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 32844325000.0
+    - amount: 32844325000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 32847445000

--- a/_data/2017-18/national/departments/home-affairs.yaml
+++ b/_data/2017-18/national/departments/home-affairs.yaml
@@ -52,7 +52,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6450822000.0
+    - amount: 6450822000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7348725000
@@ -156,7 +156,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 720919000.0
+    - amount: 720919000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 637571000
@@ -206,7 +206,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Immigration Affairs
   - items:
-    - amount: 1598202000.0
+    - amount: 1598202000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1769594000
@@ -256,7 +256,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 4131701000.0
+    - amount: 4131701000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4941560000

--- a/_data/2017-18/national/departments/human-settlements.yaml
+++ b/_data/2017-18/national/departments/human-settlements.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 30943381000.0
+    - amount: 30943381000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 30543381000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 74338000.0
+    - amount: 74338000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73538000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Human Settlements Policy, Strategy and Planning
   - items:
-    - amount: 169800000.0
+    - amount: 169800000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 165600000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Human Settlements Delivery Support
   - items:
-    - amount: 435116000.0
+    - amount: 435116000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 440616000
@@ -312,7 +312,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 30264127000.0
+    - amount: 30264127000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 29863627000

--- a/_data/2017-18/national/departments/independent-police-investigative-directorate.yaml
+++ b/_data/2017-18/national/departments/independent-police-investigative-directorate.yaml
@@ -50,7 +50,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 234781000.0
+    - amount: 234781000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 234781000
@@ -155,7 +155,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 4618000.0
+    - amount: 4618000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4468000
@@ -205,7 +205,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Compliance Monitoring and Stakeholder Management
   - items:
-    - amount: 5096000.0
+    - amount: 5096000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5476000
@@ -255,7 +255,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal Services
   - items:
-    - amount: 74245000.0
+    - amount: 74245000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 74015000
@@ -305,7 +305,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 150822000.0
+    - amount: 150822000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 150822000

--- a/_data/2017-18/national/departments/international-relations-and-cooperation.yaml
+++ b/_data/2017-18/national/departments/international-relations-and-cooperation.yaml
@@ -60,7 +60,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 5698634000.0
+    - amount: 5698634000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6510854000
@@ -164,7 +164,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 246280000.0
+    - amount: 246280000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 363557000
@@ -214,7 +214,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Diplomacy and Protocol Services
   - items:
-    - amount: 466945000.0
+    - amount: 466945000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 525201000
@@ -264,7 +264,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Cooperation
   - items:
-    - amount: 635231000.0
+    - amount: 635231000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 734321000
@@ -314,7 +314,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Transfers
   - items:
-    - amount: 1418521000.0
+    - amount: 1418521000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1381600000
@@ -364,7 +364,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 2931657000.0
+    - amount: 2931657000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3506175000

--- a/_data/2017-18/national/departments/justice-and-constitutional-development.yaml
+++ b/_data/2017-18/national/departments/justice-and-constitutional-development.yaml
@@ -69,7 +69,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 14983969000.0
+    - amount: 14983969000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15010773000
@@ -173,7 +173,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 1032176000.0
+    - amount: 1032176000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1045669000
@@ -223,7 +223,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: State Legal Services
   - items:
-    - amount: 1857833000.0
+    - amount: 1857833000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1872884000
@@ -273,7 +273,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1880769000.0
+    - amount: 1880769000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1830769000
@@ -323,7 +323,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 3193544000.0
+    - amount: 3193544000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3118544000
@@ -373,7 +373,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Auxiliary and Associated Services
   - items:
-    - amount: 3373988000.0
+    - amount: 3373988000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3394538000
@@ -423,7 +423,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Prosecuting Authority
   - items:
-    - amount: 5526428000.0
+    - amount: 5526428000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5579138000

--- a/_data/2017-18/national/departments/labour.yaml
+++ b/_data/2017-18/national/departments/labour.yaml
@@ -57,7 +57,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 2686867000.0
+    - amount: 2686867000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2704234000
@@ -161,7 +161,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 430778000.0
+    - amount: 430778000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 471830000
@@ -211,7 +211,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Inspection and Enforcement Services
   - items:
-    - amount: 488297000.0
+    - amount: 488297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 497297000
@@ -261,7 +261,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Employment Services
   - items:
-    - amount: 845111000.0
+    - amount: 845111000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 815111000
@@ -311,7 +311,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 922681000.0
+    - amount: 922681000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 919996000

--- a/_data/2017-18/national/departments/mineral-resources.yaml
+++ b/_data/2017-18/national/departments/mineral-resources.yaml
@@ -48,7 +48,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1618542000.0
+    - amount: 1618542000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1638542000
@@ -152,7 +152,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 175840000.0
+    - amount: 175840000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 184431000
@@ -202,7 +202,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Mine Health and Safety
   - items:
-    - amount: 260443000.0
+    - amount: 260443000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 263715000
@@ -252,7 +252,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Mineral Regulation
   - items:
-    - amount: 293223000.0
+    - amount: 293223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 308870000
@@ -302,7 +302,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 889036000.0
+    - amount: 889036000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 881526000

--- a/_data/2017-18/national/departments/national-treasury.yaml
+++ b/_data/2017-18/national/departments/national-treasury.yaml
@@ -93,7 +93,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 26957304000.0
+    - amount: 26957304000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 28726061000
@@ -197,7 +197,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 133892000.0
+    - amount: 133892000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 135387000
@@ -247,7 +247,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Economic Policy, Tax, Financial Regulation and Research
   - items:
-    - amount: 256965000.0
+    - amount: 256965000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 266104000
@@ -297,7 +297,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Finance and Budget Management
   - items:
-    - amount: 366665000.0
+    - amount: 366665000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 363629000
@@ -347,7 +347,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 751362000.0
+    - amount: 751362000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 807090000
@@ -397,7 +397,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Financial Accounting and Supply Chain Management Systems
   - items:
-    - amount: 1247442000.0
+    - amount: 1247442000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3254926000
@@ -447,7 +447,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Financial Relations
   - items:
-    - amount: 3116930000.0
+    - amount: 3116930000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3264890000
@@ -497,7 +497,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Asset and Liability Management
   - items:
-    - amount: 3143863000.0
+    - amount: 3143863000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2774593000
@@ -547,7 +547,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Technical Support and Development Finance
   - items:
-    - amount: 3962941000.0
+    - amount: 3962941000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3962941000
@@ -597,7 +597,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Civil and Military Pensions, Contributions to Funds and Other Benefits
   - items:
-    - amount: 4542805000.0
+    - amount: 4542805000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4562062000
@@ -647,7 +647,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Financial Intelligence and State Security
   - items:
-    - amount: 9434439000.0
+    - amount: 9434439000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9334439000
@@ -697,7 +697,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Revenue Administration
   - items:
-    - amount: 519893814000.0
+    - amount: 519893814000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 525742590000

--- a/_data/2017-18/national/departments/office-of-the-chief-justice-and-judicial-administration.yaml
+++ b/_data/2017-18/national/departments/office-of-the-chief-justice-and-judicial-administration.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 742417000.0
+    - amount: 742417000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 783379000
@@ -163,7 +163,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 32643000.0
+    - amount: 32643000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 34359000
@@ -213,7 +213,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Judicial Education and Research
   - items:
-    - amount: 69411000.0
+    - amount: 69411000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 99479000
@@ -313,7 +313,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Judicial Education and Support
   - items:
-    - amount: 640363000.0
+    - amount: 640363000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 649541000
@@ -413,7 +413,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Superior Court Services
   - items:
-    - amount: 873748000.0
+    - amount: 873748000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 873748000

--- a/_data/2017-18/national/departments/parliament.yaml
+++ b/_data/2017-18/national/departments/parliament.yaml
@@ -22,7 +22,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1566922000.0
+    - amount: 1566922000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1594238000
@@ -177,7 +177,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Strategic Leadership and Governance
   - items:
-    - amount: 133204000.0
+    - amount: 133204000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 125722000
@@ -227,7 +227,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public and International Participation
   - items:
-    - amount: 234170000.0
+    - amount: 234170000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 234170000
@@ -327,7 +327,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Support Services
   - items:
-    - amount: 364518000.0
+    - amount: 364518000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 372000000
@@ -377,7 +377,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Associated Services
   - items:
-    - amount: 375458000.0
+    - amount: 375458000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 402774000
@@ -427,7 +427,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legislation and Oversight
   - items:
-    - amount: 459572000.0
+    - amount: 459572000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 459572000
@@ -477,7 +477,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 503132000.0
+    - amount: 503132000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 503132000

--- a/_data/2017-18/national/departments/planning-monitoring-and-evaluation.yaml
+++ b/_data/2017-18/national/departments/planning-monitoring-and-evaluation.yaml
@@ -69,6 +69,9 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
+    - amount: 717694000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 754200000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -114,10 +117,10 @@ budget_actual:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
+    real:
+    - amount: 838079021
       financial_year: 2015-16
       phase: Main appropriation
-    real:
     - amount: 880708488
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -163,9 +166,6 @@ budget_actual:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
   notices:
   - Please note that the data for 2014 has not been published on vulekamali.
 budget_actual_programmes:
@@ -374,6 +374,9 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Frontline and Citizen-Based Service Delivery and Monitoring
   - items:
+    - amount: 59567000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 60431000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -408,9 +411,6 @@ budget_actual_programmes:
       financial_year: 2014-15
       phase: Audit Outcome
     - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
-    - amount: null
       financial_year: 2017-18
       phase: Main appropriation
     - amount: null
@@ -424,106 +424,9 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Institutional Performance Monitoring and Evaluation
   - items:
-    - amount: 82197000
-      financial_year: 2015-16
-      phase: Adjusted appropriation
-    - amount: 75632000
-      financial_year: 2015-16
-      phase: Final Appropriation
-    - amount: 70736000
-      financial_year: 2015-16
-      phase: Audit Outcome
-    - amount: 103237000.0
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: 91508000
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: 88233000
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: 84216000
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2014-15
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Audit Outcome
-    - amount: null
+    - amount: 69784000
       financial_year: 2015-16
       phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    name: National Planning
-  - items:
-    - amount: 92324000
-      financial_year: 2015-16
-      phase: Adjusted appropriation
-    - amount: 90087000
-      financial_year: 2015-16
-      phase: Final Appropriation
-    - amount: 89560000
-      financial_year: 2015-16
-      phase: Audit Outcome
-    - amount: 108854000.0
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: 91751000
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: 93162000
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: 89749000
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2014-15
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2014-15
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    name: Outcomes Monitoring and Evaluation
-  - items:
     - amount: 104185000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -569,10 +472,107 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
+    name: Administration
+  - items:
+    - amount: 85604000
       financial_year: 2015-16
       phase: Main appropriation
-    name: Administration
+    - amount: 92324000
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: 90087000
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: 89560000
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: 108854000.0
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: 91751000
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: 93162000
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: 89749000
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2014-15
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    name: Outcomes Monitoring and Evaluation
+  - items:
+    - amount: 88197000
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: 82197000
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: 75632000
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: 70736000
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: 103237000.0
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: 91508000
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: 88233000
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: 84216000
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2014-15
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    name: National Planning
   - items:
     - amount: 109421000.0
       financial_year: 2017-18
@@ -624,6 +624,9 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Evidence and Knowledge Systems
   - items:
+    - amount: 414542000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 415063000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -669,9 +672,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
     name: National Youth Development
 contributed_datasets:
 - contributor: International Budget Partnership

--- a/_data/2017-18/national/departments/police.yaml
+++ b/_data/2017-18/national/departments/police.yaml
@@ -33,7 +33,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 76377059000.0
+    - amount: 76377059000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 76720848000
@@ -137,7 +137,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 2331523000.0
+    - amount: 2331523000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2427731000
@@ -187,7 +187,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Protection and Security Services
   - items:
-    - amount: 3110379000.0
+    - amount: 3110379000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3146936000
@@ -237,7 +237,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Crime Intelligence
   - items:
-    - amount: 15815983000.0
+    - amount: 15815983000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16092427000
@@ -287,7 +287,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Detective Services
   - items:
-    - amount: 16264210000.0
+    - amount: 16264210000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16609332000
@@ -337,7 +337,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 38854964000.0
+    - amount: 38854964000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 38444422000

--- a/_data/2017-18/national/departments/public-enterprises.yaml
+++ b/_data/2017-18/national/departments/public-enterprises.yaml
@@ -43,7 +43,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 267481000.0
+    - amount: 267481000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23302594000
@@ -147,7 +147,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 23829000.0
+    - amount: 23829000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23509000
@@ -197,7 +197,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal and Governance
   - items:
-    - amount: 85065000.0
+    - amount: 85065000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23117211000
@@ -247,7 +247,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Portfolio Management and Strategic Partnerships
   - items:
-    - amount: 158587000.0
+    - amount: 158587000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 161874000

--- a/_data/2017-18/national/departments/public-service-and-administration.yaml
+++ b/_data/2017-18/national/departments/public-service-and-administration.yaml
@@ -70,7 +70,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 930868000.0
+    - amount: 930868000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 941482000
@@ -174,7 +174,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 21493000.0
+    - amount: 21493000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 21493000
@@ -224,7 +224,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Government Chief Information Officer
   - items:
-    - amount: 37465000.0
+    - amount: 37465000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 38606000
@@ -274,7 +274,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy Development, Research and Analysis
   - items:
-    - amount: 68607000.0
+    - amount: 68607000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73607000
@@ -324,7 +324,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Labour Relations and Human Resource Management
   - items:
-    - amount: 219702000.0
+    - amount: 219702000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 221441000
@@ -374,7 +374,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 269027000.0
+    - amount: 269027000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 272871000
@@ -424,7 +424,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Governance of Public Administration
   - items:
-    - amount: 314574000.0
+    - amount: 314574000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 313464000

--- a/_data/2017-18/national/departments/public-works.yaml
+++ b/_data/2017-18/national/departments/public-works.yaml
@@ -68,7 +68,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6411087000.0
+    - amount: 6411087000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6312222000
@@ -172,7 +172,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 47223000.0
+    - amount: 47223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 45723000
@@ -222,7 +222,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Intergovernmental Coordination
   - items:
-    - amount: 92672000.0
+    - amount: 92672000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 92822000
@@ -272,7 +272,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Prestige Policy
   - items:
-    - amount: 475996000.0
+    - amount: 475996000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 477346000
@@ -322,7 +322,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1992234000.0
+    - amount: 1992234000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1953369000
@@ -372,7 +372,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Expanded Public Works Programme
   - items:
-    - amount: 3802962000.0
+    - amount: 3802962000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3742962000

--- a/_data/2017-18/national/departments/rural-development-and-land-reform.yaml
+++ b/_data/2017-18/national/departments/rural-development-and-land-reform.yaml
@@ -59,7 +59,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 9379684000.0
+    - amount: 9379684000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9197361000
@@ -163,7 +163,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 799903000.0
+    - amount: 799903000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 748063000
@@ -213,7 +213,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Geomatics Management Services
   - items:
-    - amount: 1264265000.0
+    - amount: 1264265000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1324944000
@@ -263,7 +263,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1975739000.0
+    - amount: 1975739000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1984577000
@@ -313,7 +313,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rural Development
   - items:
-    - amount: 2602669000.0
+    - amount: 2602669000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2602669000
@@ -363,7 +363,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Restitution
   - items:
-    - amount: 2737108000.0
+    - amount: 2737108000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2537108000

--- a/_data/2017-18/national/departments/science-and-technology.yaml
+++ b/_data/2017-18/national/departments/science-and-technology.yaml
@@ -53,7 +53,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 7482120000.0
+    - amount: 7482119996
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7466106000
@@ -102,7 +102,7 @@ budget_actual:
       financial_year: 2014-15
       phase: Audit Outcome
     real:
-    - amount: 8737160692
+    - amount: 8737160687
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 8718460525
@@ -158,7 +158,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 121997000.0
+    - amount: 121997000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 121359000
@@ -208,7 +208,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Cooperation and Resources
   - items:
-    - amount: 299776000.0
+    - amount: 299776000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 300537000
@@ -258,7 +258,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1008817000.0
+    - amount: 1008817000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1008514000
@@ -358,7 +358,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Socioeconomic Innovation Partnerships
   - items:
-    - amount: 1804464000.0
+    - amount: 1804464000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1796871000
@@ -408,7 +408,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Socio-Economic Innovation Partnerships
   - items:
-    - amount: 4247066000.0
+    - amount: 4247065996
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4238825000

--- a/_data/2017-18/national/departments/small-business-development.yaml
+++ b/_data/2017-18/national/departments/small-business-development.yaml
@@ -56,7 +56,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1103188000.0
+    - amount: 1103188000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1127520000
@@ -161,9 +161,6 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 15188000.0
-      financial_year: 2015-16
-      phase: Main appropriation
     - amount: 11711000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -185,6 +182,9 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2014-15
       phase: Audit Outcome
+    - amount: null
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -210,6 +210,56 @@ budget_actual_programmes:
       financial_year: 2017-18
       phase: Audit Outcome
     name: Cooperatives Support and Development
+  - items:
+    - amount: 15188000
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2014-15
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    name: Co-operatives Support and Development
   - items:
     - amount: 25835000
       financial_year: 2016-17
@@ -311,7 +361,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Small Medium and Micro Enterprises and Cooperatives Policy and Research
   - items:
-    - amount: 64025000.0
+    - amount: 64025000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 81387000
@@ -361,7 +411,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1023975000.0
+    - amount: 1023975000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1034422000

--- a/_data/2017-18/national/departments/social-development.yaml
+++ b/_data/2017-18/national/departments/social-development.yaml
@@ -59,7 +59,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 138168640000.0
+    - amount: 138168640000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 137893640000
@@ -163,7 +163,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 297015000.0
+    - amount: 297015000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 297015000
@@ -213,7 +213,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 359820000.0
+    - amount: 359820000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 359820000
@@ -263,7 +263,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Policy and Integrated Service Delivery
   - items:
-    - amount: 662362000.0
+    - amount: 662362000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 677362000
@@ -313,7 +313,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Welfare Services Policy Development and Implementation Support
   - items:
-    - amount: 6756165000.0
+    - amount: 6756165000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6741165000
@@ -363,7 +363,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Security Policy and Administration
   - items:
-    - amount: 130093278000.0
+    - amount: 130093278000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 129818278000

--- a/_data/2017-18/national/departments/sport-and-recreation-south-africa.yaml
+++ b/_data/2017-18/national/departments/sport-and-recreation-south-africa.yaml
@@ -42,7 +42,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 988548000.0
+    - amount: 988548000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 980879000
@@ -146,7 +146,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 9678000.0
+    - amount: 9678000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6788000
@@ -196,7 +196,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Sport Infrastructure Support
   - items:
-    - amount: 92152000.0
+    - amount: 92152000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 75552000
@@ -246,7 +246,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Winning Nation
   - items:
-    - amount: 124828000.0
+    - amount: 124828000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 115477000
@@ -296,7 +296,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 133244000.0
+    - amount: 133244000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 154017000
@@ -346,7 +346,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Sport Support
   - items:
-    - amount: 628646000.0
+    - amount: 628646000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 629045000

--- a/_data/2017-18/national/departments/statistics-south-africa.yaml
+++ b/_data/2017-18/national/departments/statistics-south-africa.yaml
@@ -45,7 +45,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 2245208000.0
+    - amount: 2245208000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2323256000
@@ -149,7 +149,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 66286000.0
+    - amount: 66286000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 64587000
@@ -199,7 +199,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Methodology, Standards and Research
   - items:
-    - amount: 133675000.0
+    - amount: 133675000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 144882000
@@ -249,7 +249,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Population and Social Statistics
   - items:
-    - amount: 214445000.0
+    - amount: 214445000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 215868000
@@ -299,7 +299,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Economic Statistics
   - items:
-    - amount: 235976000.0
+    - amount: 235976000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 241152000
@@ -349,7 +349,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Survey Operations
   - items:
-    - amount: 250004000.0
+    - amount: 250004000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 246106000
@@ -399,7 +399,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Statistical Support and Informatics
   - items:
-    - amount: 553560000.0
+    - amount: 553560000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 556828000
@@ -449,7 +449,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Statistical Collection and Outreach
   - items:
-    - amount: 791262000.0
+    - amount: 791262000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 853833000

--- a/_data/2017-18/national/departments/telecommunications-and-postal-services.yaml
+++ b/_data/2017-18/national/departments/telecommunications-and-postal-services.yaml
@@ -62,7 +62,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1413328000.0
+    - amount: 1413328000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1405253000
@@ -167,7 +167,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 43447000.0
+    - amount: 43447000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 43447000
@@ -217,7 +217,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Affairs and Trade
   - items:
-    - amount: 105578000.0
+    - amount: 105578000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 105578000
@@ -267,7 +267,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Research and Capacity Development
   - items:
-    - amount: 173650000.0
+    - amount: 173650000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 180349000
@@ -317,7 +317,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 447889000.0
+    - amount: 447889000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 447889000
@@ -367,7 +367,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: ICT Enterprise Development and SOE Oversight
   - items:
-    - amount: 642764000.0
+    - amount: 642764000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 627990000

--- a/_data/2017-18/national/departments/the-presidency.yaml
+++ b/_data/2017-18/national/departments/the-presidency.yaml
@@ -47,7 +47,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 510330000.0
+    - amount: 510330000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 475929000
@@ -151,7 +151,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 5726000.0
+    - amount: 5726000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5726000
@@ -201,7 +201,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 26390000.0
+    - amount: 26390000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 32268000
@@ -251,7 +251,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Executive Support
   - items:
-    - amount: 483940000.0
+    - amount: 483940000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 443661000

--- a/_data/2017-18/national/departments/tourism.yaml
+++ b/_data/2017-18/national/departments/tourism.yaml
@@ -42,7 +42,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1800233000.0
+    - amount: 1800233000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1794178000
@@ -147,7 +147,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 46726000.0
+    - amount: 46726000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 47308000
@@ -197,7 +197,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Tourism
   - items:
-    - amount: 231773000.0
+    - amount: 231773000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 233656000
@@ -297,7 +297,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Enterprise and Visitor Support Services
   - items:
-    - amount: 306163000.0
+    - amount: 306163000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 307000000
@@ -447,7 +447,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Tourism Policy and Planning
   - items:
-    - amount: 1215571000.0
+    - amount: 1215571000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1206214000

--- a/_data/2017-18/national/departments/trade-and-industry.yaml
+++ b/_data/2017-18/national/departments/trade-and-industry.yaml
@@ -71,7 +71,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 9593715000.0
+    - amount: 9593715000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9497844000
@@ -226,7 +226,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Investment South Africa
   - items:
-    - amount: 164754000.0
+    - amount: 164754000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 116576000
@@ -276,7 +276,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Trade and Economic Development
   - items:
-    - amount: 263224000.0
+    - amount: 263224000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 89704000
@@ -326,7 +326,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Special Economic Zones and Economic Transformation
   - items:
-    - amount: 294496000.0
+    - amount: 294496000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 296385000
@@ -426,7 +426,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade Export South Africa
   - items:
-    - amount: 412328000.0
+    - amount: 412328000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 435016000
@@ -476,7 +476,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade and Investment South Africa
   - items:
-    - amount: 689740000.0
+    - amount: 689740000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 768304000
@@ -526,7 +526,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1973534000.0
+    - amount: 1973534000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1964268000
@@ -576,7 +576,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Industrial Development
   - items:
-    - amount: 5795639000.0
+    - amount: 5795639000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5827591000

--- a/_data/2017-18/national/departments/transport.yaml
+++ b/_data/2017-18/national/departments/transport.yaml
@@ -57,7 +57,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 53357297000.0
+    - amount: 53357297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 53615077000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Main appropriation
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 80583000.0
+    - amount: 80583000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 88083000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Integrated Transport Planning
   - items:
-    - amount: 111089000.0
+    - amount: 111089000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 121089000
@@ -312,7 +312,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Maritime Transport
   - items:
-    - amount: 149526000.0
+    - amount: 149526000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 149526000
@@ -362,7 +362,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Civil Aviation
   - items:
-    - amount: 383457000.0
+    - amount: 383457000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 383457000
@@ -412,7 +412,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 11536361000.0
+    - amount: 11536361000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11518861000
@@ -462,7 +462,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Transport
   - items:
-    - amount: 18311364000.0
+    - amount: 18311364000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 18311364000
@@ -512,7 +512,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rail Transport
   - items:
-    - amount: 22784917000.0
+    - amount: 22784917000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23042697000

--- a/_data/2017-18/national/departments/water-and-sanitation.yaml
+++ b/_data/2017-18/national/departments/water-and-sanitation.yaml
@@ -66,7 +66,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 16446530000.0
+    - amount: 16446530000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15746530000
@@ -171,7 +171,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 231339000.0
+    - amount: 231339000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 284609000
@@ -221,7 +221,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water Sector Regulation
   - items:
-    - amount: 808655000.0
+    - amount: 808655000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 743963000
@@ -271,7 +271,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water Planning and Information Management
   - items:
-    - amount: 1444582000.0
+    - amount: 1444582000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1414674000
@@ -321,7 +321,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water and Sanitation Services
   - items:
-    - amount: 1526167000.0
+    - amount: 1526167000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1487534000
@@ -371,7 +371,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 12435787000.0
+    - amount: 12435787000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11815750000

--- a/_data/2017-18/national/departments/women.yaml
+++ b/_data/2017-18/national/departments/women.yaml
@@ -40,7 +40,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 187002000.0
+    - amount: 187002000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 189102000
@@ -145,7 +145,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 6170000.0
+    - amount: 6170000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6328000
@@ -195,7 +195,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Research, Policy Coordination and Knowledge Management
   - items:
-    - amount: 13151000.0
+    - amount: 13151000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16967000
@@ -295,7 +295,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Stakeholder Coordination and Knowledge Management
   - items:
-    - amount: 80451000.0
+    - amount: 80451000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 78876000
@@ -395,7 +395,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Transformation and Economic Empowerment
   - items:
-    - amount: 87230000.0
+    - amount: 87230000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 86931000

--- a/_data/2018-19/national/departments/agriculture-forestry-and-fisheries.yaml
+++ b/_data/2018-19/national/departments/agriculture-forestry-and-fisheries.yaml
@@ -72,7 +72,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6383007000.0
+    - amount: 6383007000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6408750000
@@ -175,7 +175,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 238162000.0
+    - amount: 238162000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 233907000
@@ -225,7 +225,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade Promotion and Market Access
   - items:
-    - amount: 443267000.0
+    - amount: 443267000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 465267000
@@ -275,7 +275,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Fisheries
   - items:
-    - amount: 729947000.0
+    - amount: 729947000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 739418000
@@ -325,7 +325,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 906564000.0
+    - amount: 906564000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 906216000
@@ -375,7 +375,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Forestry and Natural Resources Management
   - items:
-    - amount: 1930297000.0
+    - amount: 1930297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1919401000
@@ -425,7 +425,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Food Security and Agrarian Reform
   - items:
-    - amount: 2134770000.0
+    - amount: 2134770000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2144541000

--- a/_data/2018-19/national/departments/arts-and-culture.yaml
+++ b/_data/2018-19/national/departments/arts-and-culture.yaml
@@ -72,7 +72,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 3919859000.0
+    - amount: 3919859000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3826047000
@@ -175,7 +175,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 244012000.0
+    - amount: 244012000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 242412000
@@ -225,7 +225,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 424058000.0
+    - amount: 424058000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 397558000
@@ -275,7 +275,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Institutional Governance
   - items:
-    - amount: 1076224000.0
+    - amount: 1076224000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1076224000
@@ -325,7 +325,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Arts and Culture Promotion and Development
   - items:
-    - amount: 2175565000.0
+    - amount: 2175565000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2109853000

--- a/_data/2018-19/national/departments/basic-education.yaml
+++ b/_data/2018-19/national/departments/basic-education.yaml
@@ -74,7 +74,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 21511140000.0
+    - amount: 21511140000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 21286426000
@@ -177,7 +177,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 357697000.0
+    - amount: 357697000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 360297000
@@ -227,7 +227,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1171484000.0
+    - amount: 1171484000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1163353000
@@ -277,7 +277,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Teachers, Education Human Resources and Institutional Development
   - items:
-    - amount: 1877765000.0
+    - amount: 1877765000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1844922000
@@ -327,7 +327,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Curriculum Policy, Support and Monitoring
   - items:
-    - amount: 5974456000.0
+    - amount: 5974456000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5943822000
@@ -377,7 +377,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Educational Enrichment Services
   - items:
-    - amount: 12129738000.0
+    - amount: 12129738000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11974032000

--- a/_data/2018-19/national/departments/communications.yaml
+++ b/_data/2018-19/national/departments/communications.yaml
@@ -57,7 +57,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1280888000.0
+    - amount: 1280888000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1290888000
@@ -160,7 +160,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 7897000.0
+    - amount: 7897000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7897000
@@ -210,7 +210,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Communications Policy, Research and Development
   - items:
-    - amount: 10197000.0
+    - amount: 10197000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20197000
@@ -260,7 +260,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Industry and Capacity Development
   - items:
-    - amount: 42414000.0
+    - amount: 42414000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 42414000
@@ -310,7 +310,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1220380000.0
+    - amount: 1220380000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1220380000

--- a/_data/2018-19/national/departments/cooperative-governance-and-traditional-affairs.yaml
+++ b/_data/2018-19/national/departments/cooperative-governance-and-traditional-affairs.yaml
@@ -70,7 +70,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 69314159000.0
+    - amount: 69314159000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 70815477000
@@ -174,7 +174,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 22081000.0
+    - amount: 22081000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20281000
@@ -224,7 +224,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Research and Knowledge Management
   - items:
-    - amount: 119447000.0
+    - amount: 119447000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 125928000
@@ -274,7 +274,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Traditional Affairs
   - items:
-    - amount: 247969000.0
+    - amount: 247969000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 240088000
@@ -324,7 +324,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 328092000.0
+    - amount: 328092000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 328092000
@@ -474,7 +474,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Local Government Support and Intervention Management
   - items:
-    - amount: 606805000.0
+    - amount: 606805000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 606805000
@@ -574,7 +574,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Community Work Programme
   - items:
-    - amount: 17668420000.0
+    - amount: 17668420000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 17668420000
@@ -624,7 +624,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Infrastructure and Economic Development
   - items:
-    - amount: 50321345000.0
+    - amount: 50321345000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 51825863000

--- a/_data/2018-19/national/departments/correctional-services.yaml
+++ b/_data/2018-19/national/departments/correctional-services.yaml
@@ -56,7 +56,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 20617584000.0
+    - amount: 20617584000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 20588554000
@@ -159,7 +159,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 891196000.0
+    - amount: 891196000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 890966000
@@ -209,7 +209,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Reintegration
   - items:
-    - amount: 1151993000.0
+    - amount: 1151993000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1155293000
@@ -259,7 +259,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rehabilitation
   - items:
-    - amount: 1796262000.0
+    - amount: 1796262000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1796262000
@@ -309,7 +309,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Care
   - items:
-    - amount: 3697275000.0
+    - amount: 3697275000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3694515000
@@ -359,7 +359,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 13080858000.0
+    - amount: 13080858000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 13051518000

--- a/_data/2018-19/national/departments/defence-and-military-veterans.yaml
+++ b/_data/2018-19/national/departments/defence-and-military-veterans.yaml
@@ -53,7 +53,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 44579390000.0
+    - amount: 44579390000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 45088161000
@@ -156,7 +156,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 827451000.0
+    - amount: 827451000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 831459000
@@ -206,7 +206,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Defence Intelligence
   - items:
-    - amount: 3603153000.0
+    - amount: 3603153000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3813309000
@@ -256,7 +256,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Force Employment
   - items:
-    - amount: 3717249000.0
+    - amount: 3717249000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3769147000
@@ -306,7 +306,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Maritime Defence
   - items:
-    - amount: 3932914000.0
+    - amount: 3932914000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4069261000
@@ -356,7 +356,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Military Health Support
   - items:
-    - amount: 4827173000.0
+    - amount: 4827173000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4862401000
@@ -406,7 +406,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 5816992000.0
+    - amount: 5816992000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5372614000
@@ -456,7 +456,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: General Support
   - items:
-    - amount: 7049155000.0
+    - amount: 7049155000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7167594000
@@ -506,7 +506,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Air Defence
   - items:
-    - amount: 14805303000.0
+    - amount: 14805303000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15202376000

--- a/_data/2018-19/national/departments/economic-development.yaml
+++ b/_data/2018-19/national/departments/economic-development.yaml
@@ -40,7 +40,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 885778000.0
+    - amount: 885778000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 885778000
@@ -143,7 +143,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 27889000.0
+    - amount: 27889000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 27889000
@@ -193,7 +193,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Growth Path and Social Dialogue
   - items:
-    - amount: 83223000.0
+    - amount: 83223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 83223000
@@ -243,7 +243,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 774666000.0
+    - amount: 774666000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 774666000

--- a/_data/2018-19/national/departments/energy.yaml
+++ b/_data/2018-19/national/departments/energy.yaml
@@ -55,7 +55,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 7482094000.0
+    - amount: 7482094000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7267619000
@@ -158,7 +158,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 45096000.0
+    - amount: 45096000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 44096000
@@ -208,7 +208,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Energy Policy and Planning
   - items:
-    - amount: 74378000.0
+    - amount: 74378000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73378000
@@ -258,7 +258,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Petroleum and Petroleum Products Regulation
   - items:
-    - amount: 242598000.0
+    - amount: 242598000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 246598000
@@ -308,7 +308,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 654398000.0
+    - amount: 654398000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 653898000
@@ -358,7 +358,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Nuclear Energy
   - items:
-    - amount: 687327000.0
+    - amount: 687327000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 435827000
@@ -408,7 +408,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Clean Energy
   - items:
-    - amount: 5778297000.0
+    - amount: 5778297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5813822000

--- a/_data/2018-19/national/departments/environmental-affairs.yaml
+++ b/_data/2018-19/national/departments/environmental-affairs.yaml
@@ -33,7 +33,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 5947989000.0
+    - amount: 5947989000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5943297000
@@ -137,7 +137,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 79281000.0
+    - amount: 79281000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 79281000
@@ -187,7 +187,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Chemicals and Waste Management
   - items:
-    - amount: 127517000.0
+    - amount: 127517000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 133921000
@@ -287,7 +287,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal, Authorisations, Compliance and Enforcement
   - items:
-    - amount: 240149000.0
+    - amount: 240149000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 240149000
@@ -337,7 +337,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Climate Change and Air Quality
   - items:
-    - amount: 484529000.0
+    - amount: 484529000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 399529000
@@ -387,7 +387,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Oceans and Coasts
   - items:
-    - amount: 655600000.0
+    - amount: 655600000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 730600000
@@ -437,7 +437,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Biodiversity and Conservation
   - items:
-    - amount: 714049000.0
+    - amount: 714049000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 870184000
@@ -487,7 +487,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 3646864000.0
+    - amount: 3646864000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3489633000

--- a/_data/2018-19/national/departments/health.yaml
+++ b/_data/2018-19/national/departments/health.yaml
@@ -68,7 +68,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 36468018000.0
+    - amount: 36468018000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 36253925000
@@ -171,7 +171,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 225005000.0
+    - amount: 225005000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 224917000
@@ -221,7 +221,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Primary Health Care Services
   - items:
-    - amount: 457078000.0
+    - amount: 457078000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 456578000
@@ -271,7 +271,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 587807000.0
+    - amount: 587807000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 596646000
@@ -321,7 +321,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Health Insurance, Health Planning and Systems Enablement
   - items:
-    - amount: 1596919000.0
+    - amount: 1596919000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1603875000
@@ -371,7 +371,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Health Regulation and Compliance Management
   - items:
-    - amount: 14442144000.0
+    - amount: 14442144000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 14378878000
@@ -421,7 +421,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: HIV and AIDS, Tuberculosis, and Maternal and Child Health
   - items:
-    - amount: 19159065000.0
+    - amount: 19159065000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 18993031000

--- a/_data/2018-19/national/departments/higher-education-and-training.yaml
+++ b/_data/2018-19/national/departments/higher-education-and-training.yaml
@@ -79,7 +79,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 41843955000.0
+    - amount: 41843955000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 41880138000
@@ -183,7 +183,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 54843000.0
+    - amount: 54843000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 58253000
@@ -283,7 +283,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Planning, Policy and Strategy
   - items:
-    - amount: 110699000.0
+    - amount: 110699000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 112631000
@@ -333,7 +333,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Skills Development
   - items:
-    - amount: 318318000.0
+    - amount: 318318000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 359519000
@@ -483,7 +483,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Technical and Vocational Education and Training
   - items:
-    - amount: 8515770000.0
+    - amount: 8515770000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 8502290000
@@ -533,7 +533,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Vocational and Continuing Education and Training
   - items:
-    - amount: 14690000000.0
+    - amount: 14690000000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15800000000
@@ -583,7 +583,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 32844325000.0
+    - amount: 32844325000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 32847445000

--- a/_data/2018-19/national/departments/home-affairs.yaml
+++ b/_data/2018-19/national/departments/home-affairs.yaml
@@ -35,7 +35,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6450822000.0
+    - amount: 6450822000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7348725000
@@ -138,7 +138,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 720919000.0
+    - amount: 720919000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 637571000
@@ -188,7 +188,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Immigration Affairs
   - items:
-    - amount: 1598202000.0
+    - amount: 1598202000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1769594000
@@ -238,7 +238,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 4131701000.0
+    - amount: 4131701000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4941560000

--- a/_data/2018-19/national/departments/human-settlements.yaml
+++ b/_data/2018-19/national/departments/human-settlements.yaml
@@ -61,7 +61,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 30943381000.0
+    - amount: 30943381000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 30543381000
@@ -164,7 +164,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 74338000.0
+    - amount: 74338000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73538000
@@ -214,7 +214,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Human Settlements Policy, Strategy and Planning
   - items:
-    - amount: 169800000.0
+    - amount: 169800000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 165600000
@@ -264,7 +264,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Human Settlements Delivery Support
   - items:
-    - amount: 435116000.0
+    - amount: 435116000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 440616000
@@ -314,7 +314,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 30264127000.0
+    - amount: 30264127000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 29863627000

--- a/_data/2018-19/national/departments/independent-police-investigative-directorate.yaml
+++ b/_data/2018-19/national/departments/independent-police-investigative-directorate.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 234781000.0
+    - amount: 234781000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 234781000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 4618000.0
+    - amount: 4618000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4468000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Compliance Monitoring and Stakeholder Management
   - items:
-    - amount: 5096000.0
+    - amount: 5096000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5476000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal Services
   - items:
-    - amount: 74245000.0
+    - amount: 74245000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 74015000
@@ -312,7 +312,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 150822000.0
+    - amount: 150822000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 150822000

--- a/_data/2018-19/national/departments/international-relations-and-cooperation.yaml
+++ b/_data/2018-19/national/departments/international-relations-and-cooperation.yaml
@@ -48,7 +48,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 5698634000.0
+    - amount: 5698634000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6510854000
@@ -151,7 +151,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 246280000.0
+    - amount: 246280000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 363557000
@@ -201,7 +201,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Diplomacy and Protocol Services
   - items:
-    - amount: 466945000.0
+    - amount: 466945000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 525201000
@@ -251,7 +251,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Cooperation
   - items:
-    - amount: 635231000.0
+    - amount: 635231000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 734321000
@@ -301,7 +301,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Transfers
   - items:
-    - amount: 1418521000.0
+    - amount: 1418521000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1381600000
@@ -351,7 +351,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 2931657000.0
+    - amount: 2931657000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3506175000

--- a/_data/2018-19/national/departments/justice-and-constitutional-development.yaml
+++ b/_data/2018-19/national/departments/justice-and-constitutional-development.yaml
@@ -69,7 +69,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 14983969000.0
+    - amount: 14983969000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15010773000
@@ -172,7 +172,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 1032176000.0
+    - amount: 1032176000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1045669000
@@ -222,7 +222,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: State Legal Services
   - items:
-    - amount: 1857833000.0
+    - amount: 1857833000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1872884000
@@ -272,7 +272,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1880769000.0
+    - amount: 1880769000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1830769000
@@ -322,7 +322,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 3193544000.0
+    - amount: 3193544000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3118544000
@@ -372,7 +372,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Auxiliary and Associated Services
   - items:
-    - amount: 3373988000.0
+    - amount: 3373988000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3394538000
@@ -422,7 +422,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Prosecuting Authority
   - items:
-    - amount: 5526428000.0
+    - amount: 5526428000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5579138000

--- a/_data/2018-19/national/departments/labour.yaml
+++ b/_data/2018-19/national/departments/labour.yaml
@@ -63,7 +63,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 2686867000.0
+    - amount: 2686867000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2704234000
@@ -166,7 +166,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 430778000.0
+    - amount: 430778000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 471830000
@@ -216,7 +216,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Inspection and Enforcement Services
   - items:
-    - amount: 488297000.0
+    - amount: 488297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 497297000
@@ -266,7 +266,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Employment Services
   - items:
-    - amount: 845111000.0
+    - amount: 845111000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 815111000
@@ -316,7 +316,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 922681000.0
+    - amount: 922681000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 919996000

--- a/_data/2018-19/national/departments/mineral-resources.yaml
+++ b/_data/2018-19/national/departments/mineral-resources.yaml
@@ -41,7 +41,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1618542000.0
+    - amount: 1618542000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1638542000
@@ -144,7 +144,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 175840000.0
+    - amount: 175840000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 184431000
@@ -194,7 +194,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Mine Health and Safety
   - items:
-    - amount: 260443000.0
+    - amount: 260443000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 263715000
@@ -244,7 +244,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Mineral Regulation
   - items:
-    - amount: 293223000.0
+    - amount: 293223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 308870000
@@ -294,7 +294,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 889036000.0
+    - amount: 889036000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 881526000

--- a/_data/2018-19/national/departments/national-treasury.yaml
+++ b/_data/2018-19/national/departments/national-treasury.yaml
@@ -84,7 +84,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 26957304000.0
+    - amount: 26957304000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 28726061000
@@ -187,7 +187,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 133892000.0
+    - amount: 133892000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 135387000
@@ -237,7 +237,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Economic Policy, Tax, Financial Regulation and Research
   - items:
-    - amount: 256965000.0
+    - amount: 256965000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 266104000
@@ -287,7 +287,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Finance and Budget Management
   - items:
-    - amount: 366665000.0
+    - amount: 366665000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 363629000
@@ -337,7 +337,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 751362000.0
+    - amount: 751362000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 807090000
@@ -387,7 +387,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Financial Accounting and Supply Chain Management Systems
   - items:
-    - amount: 1247442000.0
+    - amount: 1247442000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3254926000
@@ -437,7 +437,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Financial Relations
   - items:
-    - amount: 3116930000.0
+    - amount: 3116930000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3264890000
@@ -487,7 +487,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Asset and Liability Management
   - items:
-    - amount: 3143863000.0
+    - amount: 3143863000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2774593000
@@ -537,7 +537,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Technical Support and Development Finance
   - items:
-    - amount: 3962941000.0
+    - amount: 3962941000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3962941000
@@ -587,7 +587,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Civil and Military Pensions, Contributions to Funds and Other Benefits
   - items:
-    - amount: 4542805000.0
+    - amount: 4542805000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4562062000
@@ -637,7 +637,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Financial Intelligence and State Security
   - items:
-    - amount: 9434439000.0
+    - amount: 9434439000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9334439000
@@ -687,7 +687,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Revenue Administration
   - items:
-    - amount: 519893814000.0
+    - amount: 519893814000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 525742590000

--- a/_data/2018-19/national/departments/office-of-the-chief-justice-and-judicial-administration.yaml
+++ b/_data/2018-19/national/departments/office-of-the-chief-justice-and-judicial-administration.yaml
@@ -52,7 +52,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 742417000.0
+    - amount: 742417000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 783379000
@@ -156,7 +156,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 32643000.0
+    - amount: 32643000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 34359000
@@ -206,7 +206,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Judicial Education and Research
   - items:
-    - amount: 69411000.0
+    - amount: 69411000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 99479000
@@ -306,7 +306,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Judicial Education and Support
   - items:
-    - amount: 640363000.0
+    - amount: 640363000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 649541000
@@ -406,7 +406,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Superior Court Services
   - items:
-    - amount: 873748000.0
+    - amount: 873748000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 873748000

--- a/_data/2018-19/national/departments/parliament.yaml
+++ b/_data/2018-19/national/departments/parliament.yaml
@@ -22,7 +22,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1566922000.0
+    - amount: 1566922000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1594238000
@@ -176,7 +176,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Strategic Leadership and Governance
   - items:
-    - amount: 133204000.0
+    - amount: 133204000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 125722000
@@ -226,7 +226,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public and International Participation
   - items:
-    - amount: 234170000.0
+    - amount: 234170000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 234170000
@@ -326,7 +326,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Support Services
   - items:
-    - amount: 364518000.0
+    - amount: 364518000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 372000000
@@ -376,7 +376,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Associated Services
   - items:
-    - amount: 375458000.0
+    - amount: 375458000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 402774000
@@ -426,7 +426,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legislation and Oversight
   - items:
-    - amount: 459572000.0
+    - amount: 459572000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 459572000
@@ -476,7 +476,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 503132000.0
+    - amount: 503132000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 503132000

--- a/_data/2018-19/national/departments/planning-monitoring-and-evaluation.yaml
+++ b/_data/2018-19/national/departments/planning-monitoring-and-evaluation.yaml
@@ -69,6 +69,9 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
+    - amount: 717694000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 754200000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -109,15 +112,15 @@ budget_actual:
       financial_year: 2018-19
       phase: Adjusted appropriation
     - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
-    - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
     real:
+    - amount: 838079021
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 880708488
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -157,9 +160,6 @@ budget_actual:
     - amount: 958035000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
@@ -373,6 +373,9 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Frontline and Citizen-Based Service Delivery and Monitoring
   - items:
+    - amount: 59567000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 60431000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -394,9 +397,6 @@ budget_actual_programmes:
     - amount: 61897000
       financial_year: 2016-17
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
     - amount: null
       financial_year: 2017-18
       phase: Main appropriation
@@ -423,106 +423,9 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Institutional Performance Monitoring and Evaluation
   - items:
-    - amount: 82197000
-      financial_year: 2015-16
-      phase: Adjusted appropriation
-    - amount: 75632000
-      financial_year: 2015-16
-      phase: Final Appropriation
-    - amount: 70736000
-      financial_year: 2015-16
-      phase: Audit Outcome
-    - amount: 103237000.0
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: 91508000
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: 88233000
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: 84216000
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
+    - amount: 69784000
       financial_year: 2015-16
       phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    name: National Planning
-  - items:
-    - amount: 92324000
-      financial_year: 2015-16
-      phase: Adjusted appropriation
-    - amount: 90087000
-      financial_year: 2015-16
-      phase: Final Appropriation
-    - amount: 89560000
-      financial_year: 2015-16
-      phase: Audit Outcome
-    - amount: 108854000.0
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: 91751000
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: 93162000
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: 89749000
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    name: Outcomes Monitoring and Evaluation
-  - items:
     - amount: 104185000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -563,15 +466,112 @@ budget_actual_programmes:
       financial_year: 2018-19
       phase: Adjusted appropriation
     - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
-    - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
     name: Administration
+  - items:
+    - amount: 85604000
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: 92324000
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: 90087000
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: 89560000
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: 108854000.0
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: 91751000
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: 93162000
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: 89749000
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    name: Outcomes Monitoring and Evaluation
+  - items:
+    - amount: 88197000
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: 82197000
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: 75632000
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: 70736000
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: 103237000.0
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: 91508000
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: 88233000
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: 84216000
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    name: National Planning
   - items:
     - amount: 109421000.0
       financial_year: 2017-18
@@ -623,6 +623,9 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Evidence and Knowledge Systems
   - items:
+    - amount: 414542000
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: 415063000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -662,9 +665,6 @@ budget_actual_programmes:
     - amount: 488624000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2015-16
-      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation

--- a/_data/2018-19/national/departments/police.yaml
+++ b/_data/2018-19/national/departments/police.yaml
@@ -39,7 +39,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 76377059000.0
+    - amount: 76377059000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 76720848000
@@ -142,7 +142,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 2331523000.0
+    - amount: 2331523000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2427731000
@@ -192,7 +192,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Protection and Security Services
   - items:
-    - amount: 3110379000.0
+    - amount: 3110379000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3146936000
@@ -242,7 +242,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Crime Intelligence
   - items:
-    - amount: 15815983000.0
+    - amount: 15815983000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16092427000
@@ -292,7 +292,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Detective Services
   - items:
-    - amount: 16264210000.0
+    - amount: 16264210000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16609332000
@@ -342,7 +342,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 38854964000.0
+    - amount: 38854964000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 38444422000

--- a/_data/2018-19/national/departments/public-enterprises.yaml
+++ b/_data/2018-19/national/departments/public-enterprises.yaml
@@ -53,7 +53,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 267481000.0
+    - amount: 267481000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23302594000
@@ -157,7 +157,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 23829000.0
+    - amount: 23829000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23509000
@@ -307,7 +307,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Business Enhancement, Transformation and Industrialisation
   - items:
-    - amount: 85065000.0
+    - amount: 85065000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23117211000
@@ -357,7 +357,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Portfolio Management and Strategic Partnerships
   - items:
-    - amount: 158587000.0
+    - amount: 158587000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 161874000

--- a/_data/2018-19/national/departments/public-service-and-administration.yaml
+++ b/_data/2018-19/national/departments/public-service-and-administration.yaml
@@ -58,7 +58,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 930868000.0
+    - amount: 930868000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 941482000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 21493000.0
+    - amount: 21493000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 21493000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Government Chief Information Officer
   - items:
-    - amount: 37465000.0
+    - amount: 37465000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 38606000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy Development, Research and Analysis
   - items:
-    - amount: 68607000.0
+    - amount: 68607000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 73607000
@@ -362,7 +362,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Service Employment and Conditions of Service
   - items:
-    - amount: 219702000.0
+    - amount: 219702000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 221441000
@@ -412,7 +412,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 269027000.0
+    - amount: 269027000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 272871000
@@ -462,7 +462,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Governance of Public Administration
   - items:
-    - amount: 314574000.0
+    - amount: 314574000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 313464000

--- a/_data/2018-19/national/departments/public-works.yaml
+++ b/_data/2018-19/national/departments/public-works.yaml
@@ -59,7 +59,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 6411087000.0
+    - amount: 6411087000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6312222000
@@ -162,7 +162,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 47223000.0
+    - amount: 47223000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 45723000
@@ -212,7 +212,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Intergovernmental Coordination
   - items:
-    - amount: 92672000.0
+    - amount: 92672000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 92822000
@@ -262,7 +262,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Prestige Policy
   - items:
-    - amount: 475996000.0
+    - amount: 475996000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 477346000
@@ -312,7 +312,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1992234000.0
+    - amount: 1992234000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1953369000
@@ -362,7 +362,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Expanded Public Works Programme
   - items:
-    - amount: 3802962000.0
+    - amount: 3802962000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 3742962000

--- a/_data/2018-19/national/departments/rural-development-and-land-reform.yaml
+++ b/_data/2018-19/national/departments/rural-development-and-land-reform.yaml
@@ -65,7 +65,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 9379684000.0
+    - amount: 9379684000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9197361000
@@ -168,7 +168,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 799903000.0
+    - amount: 799903000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 748063000
@@ -218,7 +218,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: National Geomatics Management Services
   - items:
-    - amount: 1264265000.0
+    - amount: 1264265000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1324944000
@@ -268,7 +268,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1975739000.0
+    - amount: 1975739000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1984577000
@@ -318,7 +318,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rural Development
   - items:
-    - amount: 2602669000.0
+    - amount: 2602669000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2602669000
@@ -368,7 +368,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Restitution
   - items:
-    - amount: 2737108000.0
+    - amount: 2737108000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2537108000

--- a/_data/2018-19/national/departments/science-and-technology.yaml
+++ b/_data/2018-19/national/departments/science-and-technology.yaml
@@ -52,7 +52,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 7482120000.0
+    - amount: 7482119996
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 7466106000
@@ -101,7 +101,7 @@ budget_actual:
       financial_year: 2018-19
       phase: Audit Outcome
     real:
-    - amount: 8737160692
+    - amount: 8737160687
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 8718460525
@@ -156,7 +156,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 121997000.0
+    - amount: 121997000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 121359000
@@ -206,7 +206,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Cooperation and Resources
   - items:
-    - amount: 299776000.0
+    - amount: 299776000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 300537000
@@ -256,7 +256,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1008817000.0
+    - amount: 1008817000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1008514000
@@ -356,7 +356,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Socioeconomic Innovation Partnerships
   - items:
-    - amount: 1804464000.0
+    - amount: 1804464000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1796871000
@@ -406,7 +406,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Socio-Economic Innovation Partnerships
   - items:
-    - amount: 4247066000.0
+    - amount: 4247065996
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 4238825000

--- a/_data/2018-19/national/departments/small-business-development.yaml
+++ b/_data/2018-19/national/departments/small-business-development.yaml
@@ -60,7 +60,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1103188000.0
+    - amount: 1103188000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1127520000
@@ -164,9 +164,6 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 15188000.0
-      financial_year: 2015-16
-      phase: Main appropriation
     - amount: 11711000
       financial_year: 2015-16
       phase: Adjusted appropriation
@@ -176,6 +173,9 @@ budget_actual_programmes:
     - amount: 11692229
       financial_year: 2015-16
       phase: Audit Outcome
+    - amount: null
+      financial_year: 2015-16
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -213,6 +213,56 @@ budget_actual_programmes:
       financial_year: 2018-19
       phase: Audit Outcome
     name: Cooperatives Support and Development
+  - items:
+    - amount: 15188000
+      financial_year: 2015-16
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2015-16
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2015-16
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2015-16
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    name: Co-operatives Support and Development
   - items:
     - amount: 22413000.0
       financial_year: 2018-19
@@ -364,7 +414,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Small Medium and Micro Enterprises and Cooperatives Policy and Research
   - items:
-    - amount: 64025000.0
+    - amount: 64025000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 81387000
@@ -464,7 +514,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Integrated Cooperative Development
   - items:
-    - amount: 1023975000.0
+    - amount: 1023975000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1034422000

--- a/_data/2018-19/national/departments/social-development.yaml
+++ b/_data/2018-19/national/departments/social-development.yaml
@@ -69,7 +69,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 138168640000.0
+    - amount: 138168640000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 137893640000
@@ -172,7 +172,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 297015000.0
+    - amount: 297015000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 297015000
@@ -222,7 +222,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 359820000.0
+    - amount: 359820000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 359820000
@@ -272,7 +272,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Policy and Integrated Service Delivery
   - items:
-    - amount: 662362000.0
+    - amount: 662362000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 677362000
@@ -322,7 +322,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Welfare Services Policy Development and Implementation Support
   - items:
-    - amount: 6756165000.0
+    - amount: 6756165000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6741165000
@@ -372,7 +372,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Security Policy and Administration
   - items:
-    - amount: 130093278000.0
+    - amount: 130093278000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 129818278000

--- a/_data/2018-19/national/departments/sport-and-recreation-south-africa.yaml
+++ b/_data/2018-19/national/departments/sport-and-recreation-south-africa.yaml
@@ -44,7 +44,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 988548000.0
+    - amount: 988548000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 980879000
@@ -147,7 +147,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 9678000.0
+    - amount: 9678000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6788000
@@ -197,7 +197,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Sport Infrastructure Support
   - items:
-    - amount: 92152000.0
+    - amount: 92152000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 75552000
@@ -247,7 +247,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Winning Nation
   - items:
-    - amount: 124828000.0
+    - amount: 124828000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 115477000
@@ -297,7 +297,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 133244000.0
+    - amount: 133244000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 154017000
@@ -347,7 +347,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Sport Support
   - items:
-    - amount: 628646000.0
+    - amount: 628646000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 629045000

--- a/_data/2018-19/national/departments/statistics-south-africa.yaml
+++ b/_data/2018-19/national/departments/statistics-south-africa.yaml
@@ -60,7 +60,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 2245208000.0
+    - amount: 2245208000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 2323256000
@@ -163,7 +163,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 66286000.0
+    - amount: 66286000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 64587000
@@ -213,7 +213,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Methodology, Standards and Research
   - items:
-    - amount: 133675000.0
+    - amount: 133675000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 144882000
@@ -263,7 +263,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Population and Social Statistics
   - items:
-    - amount: 214445000.0
+    - amount: 214445000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 215868000
@@ -313,7 +313,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Economic Statistics
   - items:
-    - amount: 235976000.0
+    - amount: 235976000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 241152000
@@ -363,7 +363,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Survey Operations
   - items:
-    - amount: 250004000.0
+    - amount: 250004000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 246106000
@@ -413,7 +413,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Statistical Support and Informatics
   - items:
-    - amount: 553560000.0
+    - amount: 553560000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 556828000
@@ -463,7 +463,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Statistical Collection and Outreach
   - items:
-    - amount: 791262000.0
+    - amount: 791262000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 853833000

--- a/_data/2018-19/national/departments/telecommunications-and-postal-services.yaml
+++ b/_data/2018-19/national/departments/telecommunications-and-postal-services.yaml
@@ -65,7 +65,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1413328000.0
+    - amount: 1413328000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1405253000
@@ -169,7 +169,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 43447000.0
+    - amount: 43447000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 43447000
@@ -219,7 +219,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Affairs and Trade
   - items:
-    - amount: 105578000.0
+    - amount: 105578000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 105578000
@@ -269,7 +269,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Research and Capacity Development
   - items:
-    - amount: 173650000.0
+    - amount: 173650000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 180349000
@@ -369,7 +369,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: ICT Enterprise Development and Public Entities Oversight
   - items:
-    - amount: 447889000.0
+    - amount: 447889000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 447889000
@@ -419,7 +419,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: ICT Enterprise Development and SOE Oversight
   - items:
-    - amount: 642764000.0
+    - amount: 642764000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 627990000

--- a/_data/2018-19/national/departments/the-presidency.yaml
+++ b/_data/2018-19/national/departments/the-presidency.yaml
@@ -38,7 +38,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 510330000.0
+    - amount: 510330000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 475929000
@@ -141,7 +141,7 @@ budget_actual_programmes:
   notices: []
   programmes:
   - items:
-    - amount: 5726000.0
+    - amount: 5726000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5726000
@@ -191,7 +191,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 26390000.0
+    - amount: 26390000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 32268000
@@ -241,7 +241,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Executive Support
   - items:
-    - amount: 483940000.0
+    - amount: 483940000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 443661000

--- a/_data/2018-19/national/departments/tourism.yaml
+++ b/_data/2018-19/national/departments/tourism.yaml
@@ -34,7 +34,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 1800233000.0
+    - amount: 1800233000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1794178000
@@ -138,7 +138,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 46726000.0
+    - amount: 46726000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 47308000
@@ -188,7 +188,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Tourism
   - items:
-    - amount: 231773000.0
+    - amount: 231773000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 233656000
@@ -288,7 +288,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Enterprise and Visitor Support Services
   - items:
-    - amount: 306163000.0
+    - amount: 306163000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 307000000
@@ -488,7 +488,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Tourism Policy and Planning
   - items:
-    - amount: 1215571000.0
+    - amount: 1215571000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1206214000

--- a/_data/2018-19/national/departments/trade-and-industry.yaml
+++ b/_data/2018-19/national/departments/trade-and-industry.yaml
@@ -69,7 +69,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 9593715000.0
+    - amount: 9593715000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 9497844000
@@ -223,7 +223,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Investment South Africa
   - items:
-    - amount: 164754000.0
+    - amount: 164754000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 116576000
@@ -273,7 +273,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: International Trade and Economic Development
   - items:
-    - amount: 263224000.0
+    - amount: 263224000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 89704000
@@ -323,7 +323,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Special Economic Zones and Economic Transformation
   - items:
-    - amount: 294496000.0
+    - amount: 294496000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 296385000
@@ -423,7 +423,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade Export South Africa
   - items:
-    - amount: 412328000.0
+    - amount: 412328000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 435016000
@@ -473,7 +473,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Trade and Investment South Africa
   - items:
-    - amount: 689740000.0
+    - amount: 689740000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 768304000
@@ -523,7 +523,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 1973534000.0
+    - amount: 1973534000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1964268000
@@ -573,7 +573,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Industrial Development
   - items:
-    - amount: 5795639000.0
+    - amount: 5795639000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 5827591000

--- a/_data/2018-19/national/departments/transport.yaml
+++ b/_data/2018-19/national/departments/transport.yaml
@@ -43,7 +43,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 53357297000.0
+    - amount: 53357297000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 53615077000
@@ -197,7 +197,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Direct charge against the National Revenue Fund
   - items:
-    - amount: 80583000.0
+    - amount: 80583000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 88083000
@@ -247,7 +247,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Integrated Transport Planning
   - items:
-    - amount: 111089000.0
+    - amount: 111089000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 121089000
@@ -297,7 +297,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Maritime Transport
   - items:
-    - amount: 149526000.0
+    - amount: 149526000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 149526000
@@ -347,7 +347,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Civil Aviation
   - items:
-    - amount: 383457000.0
+    - amount: 383457000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 383457000
@@ -397,7 +397,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 11536361000.0
+    - amount: 11536361000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11518861000
@@ -447,7 +447,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Public Transport
   - items:
-    - amount: 18311364000.0
+    - amount: 18311364000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 18311364000
@@ -497,7 +497,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Rail Transport
   - items:
-    - amount: 22784917000.0
+    - amount: 22784917000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 23042697000

--- a/_data/2018-19/national/departments/water-and-sanitation.yaml
+++ b/_data/2018-19/national/departments/water-and-sanitation.yaml
@@ -63,7 +63,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 16446530000.0
+    - amount: 16446530000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 15746530000
@@ -167,7 +167,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 231339000.0
+    - amount: 231339000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 284609000
@@ -217,7 +217,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water Sector Regulation
   - items:
-    - amount: 808655000.0
+    - amount: 808655000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 743963000
@@ -267,7 +267,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water Planning and Information Management
   - items:
-    - amount: 1444582000.0
+    - amount: 1444582000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1414674000
@@ -317,7 +317,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Water and Sanitation Services
   - items:
-    - amount: 1526167000.0
+    - amount: 1526167000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 1487534000
@@ -367,7 +367,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Administration
   - items:
-    - amount: 12435787000.0
+    - amount: 12435787000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 11815750000

--- a/_data/2018-19/national/departments/women.yaml
+++ b/_data/2018-19/national/departments/women.yaml
@@ -46,7 +46,7 @@ budget_actual:
   expenditure:
     base_financial_year: 2018-19
     nominal:
-    - amount: 187002000.0
+    - amount: 187002000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 189102000
@@ -150,7 +150,7 @@ budget_actual_programmes:
   - One or more programmes did not exist for some years displayed.
   programmes:
   - items:
-    - amount: 6170000.0
+    - amount: 6170000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 6328000
@@ -200,7 +200,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Research, Policy Coordination and Knowledge Management
   - items:
-    - amount: 13151000.0
+    - amount: 13151000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 16967000
@@ -300,7 +300,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Policy, Stakeholder Coordination and Knowledge Management
   - items:
-    - amount: 80451000.0
+    - amount: 80451000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 78876000
@@ -400,7 +400,7 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Social Transformation and Economic Empowerment
   - items:
-    - amount: 87230000.0
+    - amount: 87230000
       financial_year: 2015-16
       phase: Main appropriation
     - amount: 86931000

--- a/_data/2019-20/national/departments/agriculture-forestry-and-fisheries.yaml
+++ b/_data/2019-20/national/departments/agriculture-forestry-and-fisheries.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 7732803000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7664889000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 7732803000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7288918248
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 273919000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 290885000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 487811000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 519723000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 951663000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 935725000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 1617135000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1039051000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 2037796000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2237026000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 2364479000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2642479000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/arts-and-culture.yaml
+++ b/_data/2019-20/national/departments/arts-and-culture.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 4338737000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4617485000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 4338737000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4390992573
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 310317000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 308274000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 287823000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 150393000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 1167540000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1132238000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 2573057000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 3026580000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/basic-education.yaml
+++ b/_data/2019-20/national/departments/basic-education.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 23699583000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 24504531000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 23699583000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 23302558350
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 472145000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 496253000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 1313041000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1366199000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 1867116000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1988959000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 7108968000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7508789000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 12938313000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 13144331000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/communications.yaml
+++ b/_data/2019-20/national/departments/communications.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 1516246000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1576091000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 1516246000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1498782102
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 11246000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 16412000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 45307000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 47449000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 70424000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 64879000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 1389269000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1447351000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/cooperative-governance-and-traditional-affairs.yaml
+++ b/_data/2019-20/national/departments/cooperative-governance-and-traditional-affairs.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 85037011000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 90717787000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 85037011000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 86267985501
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 278456000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 275708000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 104375000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 966599000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 15708073000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 15259803000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 1967668000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 761231000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 3863703000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4084119000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 63114736000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 69370327000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/correctional-services.yaml
+++ b/_data/2019-20/national/departments/correctional-services.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 23848973000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 25407638000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 23848973000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 24161367016
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 968001000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1042353000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 1810137000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1994849000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 2332629000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2444582000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 4387803000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4786272000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 14350403000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 15139582000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/defence-and-military-veterans.yaml
+++ b/_data/2019-20/national/departments/defence-and-military-veterans.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 48496235000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 50512992000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 48496235000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 48035277376
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 950364000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1020469000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 3375584000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 3620718000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 4699355000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4517878000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 4714062000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 5375266000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 5653274000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 6187144000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 6181596000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 6349471000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -442,15 +441,15 @@ budget_actual_programmes:
     - amount: 6650779000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 6977747000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -492,15 +491,15 @@ budget_actual_programmes:
     - amount: 16271221000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 16464299000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/economic-development.yaml
+++ b/_data/2019-20/national/departments/economic-development.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 1072597000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1045393000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 1072597000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 994115389
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 34495000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 37009000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 86351000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 90334000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 951751000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 918050000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/energy.yaml
+++ b/_data/2019-20/national/departments/energy.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 7163532000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7440021000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 7163532000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7075080256
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 50078000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 54668000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 86132000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 91269000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 283388000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 308264000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 484707000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 408083000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 875586000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1045912000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 5383641000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 5531825000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/environmental-affairs.yaml
+++ b/_data/2019-20/national/departments/environmental-affairs.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 7430532000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7529671000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 7430532000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7160332831
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -143,15 +142,15 @@ budget_actual_programmes:
     - amount: 550254000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 594316000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -219,39 +218,39 @@ budget_actual_programmes:
     - amount: 189324000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 207527000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -313,6 +312,56 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Climate Change and Air Quality
   - items:
+    - amount: 445939000
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: Climate Change, Air Quality and Sustainable Development
+  - items:
     - amount: 475041000.0
       financial_year: 2016-17
       phase: Main appropriation
@@ -343,15 +392,15 @@ budget_actual_programmes:
     - amount: 491995000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 507228000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -393,15 +442,15 @@ budget_actual_programmes:
     - amount: 773350000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 797320000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -443,15 +492,15 @@ budget_actual_programmes:
     - amount: 941820000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 891872000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -493,15 +542,15 @@ budget_actual_programmes:
     - amount: 4189281000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4085469000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/health.yaml
+++ b/_data/2019-20/national/departments/health.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 47508374000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 51460690000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 47508374000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 48936489807
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,12 +105,62 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
-  notices: []
+  notices:
+  - One or more programmes did not exist for some years displayed.
   programmes:
+  - items:
+    - amount: 221751000
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: Primary Health Care
   - items:
     - amount: 257839000.0
       financial_year: 2016-17
@@ -192,15 +242,15 @@ budget_actual_programmes:
     - amount: 537146000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 661277000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -312,6 +362,106 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Health Regulation and Compliance Management
   - items:
+    - amount: 2111663000
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: National Health Insurance
+  - items:
+    - amount: 5077589000
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: Health System Governance and Human Resources
+  - items:
     - amount: 16018568000.0
       financial_year: 2016-17
       phase: Main appropriation
@@ -411,6 +561,106 @@ budget_actual_programmes:
       financial_year: 2019-20
       phase: Audit Outcome
     name: Hospitals, Tertiary Health Services and Human Resource Development
+  - items:
+    - amount: 20381141000
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: Hospital Systems
+  - items:
+    - amount: 23007269000
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: Communicable and Non-communicable Diseases
 contributed_datasets:
 - contributor: International Budget Partnership
   name: How Does Civil Society Use Budget Information?

--- a/_data/2019-20/national/departments/higher-education-and-training.yaml
+++ b/_data/2019-20/national/departments/higher-education-and-training.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 73124073000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 89498183000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 73124073000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 85108204342
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 79904000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 90771000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 264489000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 282381000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 446587000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 460430000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 2355597000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2532819000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 10727339000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 12721834000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 17312161000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 18758510000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -442,15 +441,15 @@ budget_actual_programmes:
     - amount: 59250157000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 73409948000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/home-affairs.yaml
+++ b/_data/2019-20/national/departments/home-affairs.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 9047439000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 8339704000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 9047439000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7930632873
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 1073609000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1262766000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 2525133000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2340209000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 5448697000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4736729000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/human-settlements.yaml
+++ b/_data/2019-20/national/departments/human-settlements.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 32455843000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 33879166000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 32455843000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 32217357785
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 92681000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 104657000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 246005000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 258746000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 439750000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 464667000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 31677407000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 33051096000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/independent-police-investigative-directorate.yaml
+++ b/_data/2019-20/national/departments/independent-police-investigative-directorate.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 315113000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 336652986
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 315113000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 320139808
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -163,6 +162,56 @@ budget_actual_programmes:
       phase: Audit Outcome
     name: Legal Services
   - items:
+    - amount: 7513167
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: Legal and Investigation Advisory Services
+  - items:
     - amount: 8901000.0
       financial_year: 2016-17
       phase: Main appropriation
@@ -193,15 +242,15 @@ budget_actual_programmes:
     - amount: 12394000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 15578000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -243,15 +292,15 @@ budget_actual_programmes:
     - amount: 106504000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 107571391
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -293,15 +342,15 @@ budget_actual_programmes:
     - amount: 196215000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 205990428
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/international-relations-and-cooperation.yaml
+++ b/_data/2019-20/national/departments/international-relations-and-cooperation.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 6552768000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 6508515000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 6552768000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 6189265591
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 342928000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 322941000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 657355000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 855611000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 527478000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 564168000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 1649446000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1711268000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 3375561000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 3054527000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/justice-and-constitutional-development.yaml
+++ b/_data/2019-20/national/departments/justice-and-constitutional-development.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 17458829000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 18717077000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 17458829000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 17798984969
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 1245827000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1349790000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 2215538000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2383695000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 2502482000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2504495000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 3630636000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4108755000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 3648849000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 3929137000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 6431035000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 6824900000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/labour.yaml
+++ b/_data/2019-20/national/departments/labour.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 3282870000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 3435133000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 3282870000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 3266636165
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 580574000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 611198000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 592223000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 631133000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 906631000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 961959000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 1203442000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1230843000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/mineral-resources.yaml
+++ b/_data/2019-20/national/departments/mineral-resources.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 1890661000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2005220000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 1890661000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1906861880
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 205037000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 218570000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 393606000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 443664000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 335000000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 345454000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 957018000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 997532000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/national-treasury.yaml
+++ b/_data/2019-20/national/departments/national-treasury.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 29710233000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 30771079000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 29710233000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 29261725675
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 101585000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 108428000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 152770000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 149713000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 298047000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 320006000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 473819000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 555720000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 1194148000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1093586000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 3012542000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2737557000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -442,15 +441,15 @@ budget_actual_programmes:
     - amount: 5163796000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 5574503000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -492,15 +491,15 @@ budget_actual_programmes:
     - amount: 4763533000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4951053000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -542,15 +541,15 @@ budget_actual_programmes:
     - amount: 5542776000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 5751482000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -592,15 +591,15 @@ budget_actual_programmes:
     - amount: 9007217000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 9529031000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -642,15 +641,15 @@ budget_actual_programmes:
     - amount: 664004032000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 721063701000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/office-of-the-chief-justice-and-judicial-administration.yaml
+++ b/_data/2019-20/national/departments/office-of-the-chief-justice-and-judicial-administration.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 1119747000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1197692000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 1119747000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1138943965
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -181,6 +180,9 @@ budget_actual_programmes:
     - amount: 73115000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 82971000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -199,9 +201,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -243,15 +242,15 @@ budget_actual_programmes:
     - amount: 201380000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 214611000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -331,6 +330,9 @@ budget_actual_programmes:
     - amount: 845252000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 900110000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -349,9 +351,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -393,15 +392,15 @@ budget_actual_programmes:
     - amount: 1022091000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1098546000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/parliament.yaml
+++ b/_data/2019-20/national/departments/parliament.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 1872694000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1993460000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 1872694000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1895678720
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -137,21 +136,21 @@ budget_actual_programmes:
     - amount: 96926000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 105741000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -187,21 +186,21 @@ budget_actual_programmes:
     - amount: 136304000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 118523000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -237,21 +236,21 @@ budget_actual_programmes:
     - amount: 361897000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 421893000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -287,21 +286,21 @@ budget_actual_programmes:
     - amount: 579464000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 642908000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -337,21 +336,21 @@ budget_actual_programmes:
     - amount: 493161000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 527518000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -387,21 +386,21 @@ budget_actual_programmes:
     - amount: 698103000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 704395000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/planning-monitoring-and-evaluation.yaml
+++ b/_data/2019-20/national/departments/planning-monitoring-and-evaluation.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 958035000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 956939000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 958035000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 910000150
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -131,6 +130,9 @@ budget_actual_programmes:
     - amount: 44786000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 85749000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -149,9 +151,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -162,6 +161,56 @@ budget_actual_programmes:
       financial_year: 2019-20
       phase: Audit Outcome
     name: Public Sector Monitoring and Capacity Development
+  - items:
+    - amount: 46658000
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: Evaluation, Evidence and Knowledge Systems
   - items:
     - amount: 52153000.0
       financial_year: 2017-18
@@ -231,6 +280,9 @@ budget_actual_programmes:
     - amount: 81470000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 74363000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -249,9 +301,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -362,6 +411,56 @@ budget_actual_programmes:
       financial_year: 2019-20
       phase: Audit Outcome
     name: Institutional Performance Monitoring and Evaluation
+  - items:
+    - amount: 92242000
+      financial_year: 2019-20
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2019-20
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2019-20
+      phase: Audit Outcome
+    name: Sector Monitoring Services
   - items:
     - amount: 103237000.0
       financial_year: 2016-17
@@ -543,15 +642,15 @@ budget_actual_programmes:
     - amount: 170840000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 187187000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -593,15 +692,15 @@ budget_actual_programmes:
     - amount: 488624000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 470740000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/police.yaml
+++ b/_data/2019-20/national/departments/police.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 91684161000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 97595308000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 91684161000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 92808156967
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 2942375000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 3148908000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 3804713000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4092713000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 18661647000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 19994611000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 19403113000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 20446548000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 46872313000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 49912528000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/public-enterprises.yaml
+++ b/_data/2019-20/national/departments/public-enterprises.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 6522914000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 293030000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 6522914000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 278656574
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -169,39 +168,39 @@ budget_actual_programmes:
     - amount: 39084000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 43913000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -219,39 +218,39 @@ budget_actual_programmes:
     - amount: 6331851000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 84196000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -343,15 +342,15 @@ budget_actual_programmes:
     - amount: 151979000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 164921000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/public-service-and-administration.yaml
+++ b/_data/2019-20/national/departments/public-service-and-administration.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 950656000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1002143000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 950656000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 952986846
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -143,15 +142,15 @@ budget_actual_programmes:
     - amount: 22441000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 23335000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -193,15 +192,15 @@ budget_actual_programmes:
     - amount: 34108000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 36281000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -269,39 +268,39 @@ budget_actual_programmes:
     - amount: 78028000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 84375000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -343,15 +342,15 @@ budget_actual_programmes:
     - amount: 262381000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 282643000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -393,15 +392,15 @@ budget_actual_programmes:
     - amount: 240559000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 246097000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -443,15 +442,15 @@ budget_actual_programmes:
     - amount: 313139000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 329412000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/public-works.yaml
+++ b/_data/2019-20/national/departments/public-works.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 7483326000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7808988000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 7483326000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7425949043
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 56144000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 60886000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 150016000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 115427000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 483401000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 508013000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 2547275000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2680814000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 4246490000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4443848000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/rural-development-and-land-reform.yaml
+++ b/_data/2019-20/national/departments/rural-development-and-land-reform.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 10425243000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 10946208000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 10425243000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 10409285149
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 657664000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 712800000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 1877945000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1889100000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 1787249000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1821141000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 2743055000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2914974000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 3359330000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 3608193000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/science-and-technology.yaml
+++ b/_data/2019-20/national/departments/science-and-technology.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 7958388000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 8150968998
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 7958388000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7751155518
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -143,15 +142,15 @@ budget_actual_programmes:
     - amount: 137899000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 149007999
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -193,15 +192,15 @@ budget_actual_programmes:
     - amount: 379514000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 380282000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -243,15 +242,15 @@ budget_actual_programmes:
     - amount: 1131723000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1224305000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -275,33 +274,33 @@ budget_actual_programmes:
     - amount: 1612645166
       financial_year: 2017-18
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 1824439000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -393,15 +392,15 @@ budget_actual_programmes:
     - amount: 4530992000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 4572934999
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/small-business-development.yaml
+++ b/_data/2019-20/national/departments/small-business-development.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 1488453000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2568552000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 1488453000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2442561861
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -119,39 +118,39 @@ budget_actual_programmes:
     - amount: 22447000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 35615000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -269,39 +268,39 @@ budget_actual_programmes:
     - amount: 115017000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 127628000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -343,15 +342,15 @@ budget_actual_programmes:
     - amount: 127121000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 124388000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -471,39 +470,39 @@ budget_actual_programmes:
     - amount: 1223868000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 2280921000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/social-development.yaml
+++ b/_data/2019-20/national/departments/social-development.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 172822233000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 184791972000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 172822233000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 175727734202
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 391746000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 408374000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 392303000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 413282000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 1300440000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1065807000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 7877021000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7748916000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 162860723000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 175155593000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/sport-and-recreation-south-africa.yaml
+++ b/_data/2019-20/national/departments/sport-and-recreation-south-africa.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 1090777000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1153658000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 1090777000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1097069879
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 11753000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 15216000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 69790000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 83684000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 125332000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 145742000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 166634000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 164947000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 717268000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 744069000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/statistics-south-africa.yaml
+++ b/_data/2019-20/national/departments/statistics-south-africa.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 2271699000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2514368000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 2271699000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2391035642
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 75027000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 83516000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 183905000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 176841000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 248916000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 277811000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 279421000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 283907000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 189815000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 310023000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 616031000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 700218000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -442,15 +441,15 @@ budget_actual_programmes:
     - amount: 678584000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 682052000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/telecommunications-and-postal-services.yaml
+++ b/_data/2019-20/national/departments/telecommunications-and-postal-services.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 4006936000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1684574000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 4006936000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1601943898
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -143,15 +142,15 @@ budget_actual_programmes:
     - amount: 79985000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 57058000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -193,15 +192,15 @@ budget_actual_programmes:
     - amount: 84980000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 90199000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -243,15 +242,15 @@ budget_actual_programmes:
     - amount: 235207000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 276828000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -269,39 +268,39 @@ budget_actual_programmes:
     - amount: 3205149000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 744233000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -393,15 +392,15 @@ budget_actual_programmes:
     - amount: 401615000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 516256000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/the-presidency.yaml
+++ b/_data/2019-20/national/departments/the-presidency.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 505580000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 691354000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 505580000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 657442369
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 6742000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 7254000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 48436000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 67386000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 457144000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 623968000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/tourism.yaml
+++ b/_data/2019-20/national/departments/tourism.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 2261817000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2392670000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 2261817000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2275307056
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -193,15 +192,15 @@ budget_actual_programmes:
     - amount: 271415000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 291494000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -269,39 +268,39 @@ budget_actual_programmes:
     - amount: 306653000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 306826000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -331,6 +330,9 @@ budget_actual_programmes:
     - amount: 401754000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 463297000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -349,9 +351,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -519,39 +518,39 @@ budget_actual_programmes:
     - amount: 1281995000
       financial_year: 2018-19
       phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2016-17
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2017-18
-      phase: Main appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Adjusted appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2017-18
-      phase: Audit Outcome
-    - amount: null
-      financial_year: 2018-19
-      phase: Final Appropriation
-    - amount: null
-      financial_year: 2018-19
-      phase: Audit Outcome
-    - amount: null
+    - amount: 1331053000
       financial_year: 2019-20
       phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2016-17
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2017-18
+      phase: Main appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Adjusted appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2017-18
+      phase: Audit Outcome
+    - amount: null
+      financial_year: 2018-19
+      phase: Final Appropriation
+    - amount: null
+      financial_year: 2018-19
+      phase: Audit Outcome
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/trade-and-industry.yaml
+++ b/_data/2019-20/national/departments/trade-and-industry.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 9531758000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 10059027000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 9531758000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 9565621297
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -143,15 +142,15 @@ budget_actual_programmes:
     - amount: 83846000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 58039000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -193,15 +192,15 @@ budget_actual_programmes:
     - amount: 146276000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 171458000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -243,15 +242,15 @@ budget_actual_programmes:
     - amount: 124773000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 130405000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -293,15 +292,15 @@ budget_actual_programmes:
     - amount: 330347000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 328319000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -381,6 +380,9 @@ budget_actual_programmes:
     - amount: 411602000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 440456000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -399,9 +401,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -443,15 +442,15 @@ budget_actual_programmes:
     - amount: 837280000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 803475000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -493,15 +492,15 @@ budget_actual_programmes:
     - amount: 2029777000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 2100814000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -543,15 +542,15 @@ budget_actual_programmes:
     - amount: 5567857000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 6026061000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/transport.yaml
+++ b/_data/2019-20/national/departments/transport.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 59831294000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 64194177000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 59831294000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 61045386069
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -139,6 +138,9 @@ budget_actual_programmes:
     - amount: 10200000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 10424000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2016-17
       phase: Main appropriation
@@ -148,9 +150,6 @@ budget_actual_programmes:
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 89982000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 169226000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 119925000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 136771000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -292,15 +291,15 @@ budget_actual_programmes:
     - amount: 182253000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 245124000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -342,15 +341,15 @@ budget_actual_programmes:
     - amount: 430077000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 463038000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -392,15 +391,15 @@ budget_actual_programmes:
     - amount: 13023018000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 13588088000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -442,15 +441,15 @@ budget_actual_programmes:
     - amount: 15887279000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 16573782000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -492,15 +491,15 @@ budget_actual_programmes:
     - amount: 30098760000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 33018148000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/water-and-sanitation.yaml
+++ b/_data/2019-20/national/departments/water-and-sanitation.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 16873729000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 16440372000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 16873729000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 15633954709
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices:
@@ -143,15 +142,15 @@ budget_actual_programmes:
     - amount: 318695000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 462570000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -243,15 +242,15 @@ budget_actual_programmes:
     - amount: 689630000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 970348000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -293,15 +292,15 @@ budget_actual_programmes:
     - amount: 1661154000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 1832344000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -343,15 +342,15 @@ budget_actual_programmes:
     - amount: 14204250000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 13175110000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/2019-20/national/departments/women.yaml
+++ b/_data/2019-20/national/departments/women.yaml
@@ -38,15 +38,15 @@ budget_actual:
     - amount: 230207000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 244398000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -87,15 +87,15 @@ budget_actual:
     - amount: 230207000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 232410024
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -105,8 +105,7 @@ budget_actual:
     - amount: null
       financial_year: 2019-20
       phase: Audit Outcome
-  notices:
-  - Please note that the data for 2019 has not been published on vulekamali.
+  notices: []
 budget_actual_programmes:
   dataset_detail_page: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
   notices: []
@@ -142,15 +141,15 @@ budget_actual_programmes:
     - amount: 41267000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 50854000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -192,15 +191,15 @@ budget_actual_programmes:
     - amount: 109531000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 109157000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation
@@ -242,15 +241,15 @@ budget_actual_programmes:
     - amount: 79409000
       financial_year: 2018-19
       phase: Adjusted appropriation
+    - amount: 84387000
+      financial_year: 2019-20
+      phase: Main appropriation
     - amount: null
       financial_year: 2018-19
       phase: Final Appropriation
     - amount: null
       financial_year: 2018-19
       phase: Audit Outcome
-    - amount: null
-      financial_year: 2019-20
-      phase: Main appropriation
     - amount: null
       financial_year: 2019-20
       phase: Adjusted appropriation

--- a/_data/datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure.yaml
+++ b/_data/datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure.yaml
@@ -18,7 +18,7 @@ intro: "Combined dataset consisting of ENE, AENE and Annual Report expenditure d
   \n\r\nIncludes data from multiple fiscal years."
 intro_short: null
 key_points: null
-last_updated: '2019-01-17T04:40:46.709702'
+last_updated: '2019-03-14T08:58:08.281924'
 license:
   name: License not specified
   url: null
@@ -41,7 +41,7 @@ resources:
 - description: ''
   format: OpenSpending API
   name: Budgeted and Actual Expenditure
-  url: https://openspending.org/api/3/cubes/b9d2af843f3a7ca223eea07fb608e62a:expenditure-time-series-v2/model/
+  url: https://openspending.org/api/3/cubes/b9d2af843f3a7ca223eea07fb608e62a:expenditure-time-series-v3/model/
 selected_tab: datasets
 slug: budgeted-and-actual-national-expenditure
 title: Budgeted and Actual National Expenditure - vulekamali

--- a/_data/datasets/budgeted-and-actual-national-expenditure/index.yaml
+++ b/_data/datasets/budgeted-and-actual-national-expenditure/index.yaml
@@ -16,7 +16,7 @@ datasets:
   description: "Combined dataset consisting of ENE, AENE and Annual Report expenditure\
     \ data.\r\n\r\nIncludes data from multiple fiscal years."
   intro_short: null
-  last_updated: '2019-01-17T04:40:46.709702'
+  last_updated: '2019-03-14T08:58:08.281924'
   license:
     name: License not specified
     url: null
@@ -38,7 +38,7 @@ datasets:
   - description: ''
     format: OpenSpending API
     name: Budgeted and Actual Expenditure
-    url: https://openspending.org/api/3/cubes/b9d2af843f3a7ca223eea07fb608e62a:expenditure-time-series-v2/model/
+    url: https://openspending.org/api/3/cubes/b9d2af843f3a7ca223eea07fb608e62a:expenditure-time-series-v3/model/
   slug: budgeted-and-actual-national-expenditure
   url_path: /datasets/budgeted-and-actual-national-expenditure/budgeted-and-actual-national-expenditure
 description: "Expenditure data sourced from the Main Budget, Adjusted Budget and Annual\


### PR DESCRIPTION
This PR adds 2019 ENE data.

What I've done:
- Added 2019 ENE data to combo pipeline
- Uploaded new combo pipeline to OS with a new ID (`expenditure-time-series-v3`)
- Changed CKAN API link from v2 to v3
- Branched off `master` in `static-budget-portal`
- Pushed an empty commit  with `[ci]` to produce new data against production

What I've noticed:
- We've lost decimals on some data: maybe due to schema inference in the combo pipeline?
- Some 2015 data is now empty? this is trange
- Some 2015 data that was empty, is now populated?
- The 2019 data looks good.