### PR TITLE
zeeshaan fixes to focus area pages

### DIFF
--- a/packages/webapp/src/adaptors/focus-areas-preview/Routing.js
+++ b/packages/webapp/src/adaptors/focus-areas-preview/Routing.js
@@ -10,7 +10,7 @@ import {
 const passRouteValues = ({ match }) => createElement(DataLoader, match.params)
 
 const routeConfig = {
-  path: "/:year/:department",
+  path: "/:year/focus/:department",
   component: passRouteValues,
 };
 

--- a/packages/webapp/src/adaptors/focus-areas-preview/addProvinceToObject.js
+++ b/packages/webapp/src/adaptors/focus-areas-preview/addProvinceToObject.js
@@ -1,4 +1,8 @@
 const addProvinceToObject = (provincialData) => {
+  if (provincialData.length === 0) {
+    return {};
+  }
+
   return (
     ['Eastern Cape','Free State','Gauteng','Limpopo','Mpumalanga','Northern Cape','Western Cape','North West', 'KwaZulu-Natal'].reduce(
       (result, provinceName) => {

--- a/packages/webapp/src/components/ChartSection/Markup.jsx
+++ b/packages/webapp/src/components/ChartSection/Markup.jsx
@@ -81,7 +81,7 @@ const Markup = (props) => {
     <Wrapper>
       <CssBaseline />
       <SectionHeading title={title} share={anchor} years={years} phases={phases} />
-      {!!selected && callDetails(selected, verb, subject, isConsolidatedChart)} 
+      {!!selected && callDetails(selected, verb, subject, isConsolidatedChart)}
       {callChart(chart, onSelectedChange)}
       <FooterWrapper>
         <FooterContainer>

--- a/packages/webapp/src/components/ChartSection/Markup.jsx
+++ b/packages/webapp/src/components/ChartSection/Markup.jsx
@@ -30,10 +30,7 @@ import {
    </ChartWrapper>
  );
 
-const callButtonExplore = (url, color,  verb, subject, isConsolidatedChart) => {
-  if(isConsolidatedChart) {
-    return null;
-  }
+const callButtonExplore = (url, color,  verb, subject) => {
   return (
     <LinkWrapper href={url}>
       <ButtonStyle disabled={!url} {...{color}}>
@@ -44,7 +41,7 @@ const callButtonExplore = (url, color,  verb, subject, isConsolidatedChart) => {
   );
 };
 
-const callDetails = (selected, verb, subject, isConsolidatedChart) => {
+const callDetails = (selected, verb, subject) => {
   const { name, value, url, color } = selected;
   if (value === null) {
     return null;
@@ -56,7 +53,7 @@ const callDetails = (selected, verb, subject, isConsolidatedChart) => {
           <Department>{name}</Department>
           <Amount>R{trimValues(value)}</Amount>
         </div>
-        {!!verb && callButtonExplore(url, color,  verb, subject, isConsolidatedChart)}
+        {!!verb && callButtonExplore(url, color,  verb, subject)}
       </DetailsContainer>
     </DetailsWrapper>
   );
@@ -73,15 +70,14 @@ const Markup = (props) => {
     years,
     phases,
     anchor,
-    title,
-    isConsolidatedChart
+    title
   } = props;
   
   return (
     <Wrapper>
       <CssBaseline />
       <SectionHeading title={title} share={anchor} years={years} phases={phases} />
-      {!!selected && callDetails(selected, verb, subject, isConsolidatedChart)}
+      {!!selected && callDetails(selected, verb, subject)}
       {callChart(chart, onSelectedChange)}
       <FooterWrapper>
         <FooterContainer>

--- a/packages/webapp/src/views/ConsolidatedTreemap/index.jsx
+++ b/packages/webapp/src/views/ConsolidatedTreemap/index.jsx
@@ -27,7 +27,6 @@ const Markup = ({ items, initialSelected }) => (
       disabled: "2019-20",
     }}
     anchor="consolidated-treemap"
-    isConsolidatedChart
   />
 )
 

--- a/packages/webapp/src/views/FocusArea/Markup.jsx
+++ b/packages/webapp/src/views/FocusArea/Markup.jsx
@@ -20,11 +20,11 @@ const callFootNote = footnote => footnote.map(footer => (
 ))
 
 const callProvincialChart = (selected, initialSelected, items, footnotes, notices) => {
-  if(initialSelected.value === null || Object.entries(items).length === 0) {
+  if(Object.entries(items).length === 0) {
     return (
       <div key={`${selected}-provincial`}>
       <ChartSection
-        {...{ initialSelected }}
+        {...{ initialSelected  }}
         chart={() => <Notices {...{ notices }} />}
         title='Contributing provincial departments'
         anchor='contributing-provincial-departments'

--- a/packages/webapp/src/views/FocusArea/index.jsx
+++ b/packages/webapp/src/views/FocusArea/index.jsx
@@ -28,7 +28,7 @@ class Preview extends Component {
       return null;
     }
     if (updateUrl) {
-      const newUrl = `/${this.props.year}/${e.target.value}`;
+      const newUrl = `/${this.props.year}/focus/${e.target.value}`;
       window.history.pushState({}, window.document.title, newUrl );
     }
     this.setState({ selected: e.target.value });


### PR DESCRIPTION
- Fix url i.e add /focus/ to url
- Show explore button on consolidated again
- Fix live focus area page: 
    - when all data is available
    - only one footnote available for National Treemap
   - both footnote available for National Treemap
   - Show only notices when data is empty array, and total is nulll
   - Show notices and total when data is empty array and total is 0.